### PR TITLE
Fix Parcel's relative links in deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,10 @@
     "parcel": "^2.8.3",
     "prettier": "^2.8.7",
     "puppeteer": "^19.8.2"
+  },
+  "targets": {
+    "default": {
+      "publicUrl": "./"
+    }
   }
 }


### PR DESCRIPTION
Parcel was using the default of `/` for loading CSS/JS files, e.g. `href="/index.b09ca253.css"`. That tells the browser to look for `https://parking-reform.org/index.b09ca253.css"`.

Instead, we want to load the files relative to `index.html`.