### PR TITLE
Detect the geometry type automatically when updating data

### DIFF
--- a/scripts/base.js
+++ b/scripts/base.js
@@ -40,7 +40,6 @@ const determineArgs = (scriptCommand, processArgv) => {
  * @param string scriptCommand - i.e. `update-lots` or `update-city-boundaries`.
  * @param string cityName - e.g. 'My City, AZ'
  * @param boolean addCity - what to do if the city is missing
- * @param string geometryType - either `Polygon` or `MultiPolygon`
  * @param object additionalPropertiesForNewCity - any additional keys and filler values to add
       to Properties when creating a new city.
  * @param string originalFilePath - what will be updated
@@ -52,7 +51,6 @@ const updateCoordinates = async (
   scriptCommand,
   cityName,
   addCity,
-  geometryType,
   additionalPropertiesForNewCity,
   originalFilePath,
   updateFilePath
@@ -74,6 +72,7 @@ const updateCoordinates = async (
   }
 
   const newCoordinates = newData.features[0].geometry.coordinates;
+  const newGeometryType = newData.features[0].geometry.type;
 
   let originalData;
   try {
@@ -89,7 +88,7 @@ const updateCoordinates = async (
     const newEntry = {
       type: "Feature",
       properties: { Name: cityName, ...additionalPropertiesForNewCity },
-      geometry: { type: geometryType, coordinates: newCoordinates },
+      geometry: { type: newGeometryType, coordinates: newCoordinates },
     };
     originalData.features.push(newEntry);
   } else {

--- a/scripts/tests/base.test.js
+++ b/scripts/tests/base.test.js
@@ -60,7 +60,6 @@ describe("updateCoordinates()", () => {
       "my-script",
       cityName,
       false,
-      "Polygon",
       {},
       originalFilePath,
       updateFilePath
@@ -89,7 +88,6 @@ describe("updateCoordinates()", () => {
       "my-script",
       cityName,
       true,
-      "MyShape",
       { MyProperty: "Fill me in" },
       originalFilePath,
       updateFilePath
@@ -111,7 +109,7 @@ describe("updateCoordinates()", () => {
       Name: cityName,
       MyProperty: "Fill me in",
     });
-    expect(cityTargetData.geometry.type).toEqual("MyShape");
+    expect(cityTargetData.geometry.type).toEqual("MultiPolygon");
     expect(cityTargetData.geometry.coordinates).toEqual(updatedCoordinates);
   });
 
@@ -120,7 +118,6 @@ describe("updateCoordinates()", () => {
       "my-script",
       "Bad City",
       false,
-      "Polygon",
       {},
       originalFilePath,
       validUpdateFilePath
@@ -133,7 +130,6 @@ describe("updateCoordinates()", () => {
       "my-script",
       "Shoup Ville, AZ",
       false,
-      "Polygon",
       {},
       originalFilePath,
       "scripts/tests/data/too-many-updates.geojson"
@@ -144,7 +140,6 @@ describe("updateCoordinates()", () => {
       "my-script",
       "Shoup Ville, AZ",
       false,
-      "Polygon",
       {},
       originalFilePath,
       "scripts/tests/data/empty-update.geojson"
@@ -157,7 +152,6 @@ describe("updateCoordinates()", () => {
       "my-script",
       "Shoup Ville, AZ",
       false,
-      "Polygon",
       {},
       originalFilePath,
       "scripts/tests/data/does-not-exist"
@@ -170,7 +164,6 @@ describe("updateCoordinates()", () => {
       "my-script",
       "Shoup Ville, AZ",
       false,
-      "Polygon",
       {},
       "scripts/tests/data/does-not-exist",
       validUpdateFilePath

--- a/scripts/update-city.js
+++ b/scripts/update-city.js
@@ -21,7 +21,6 @@ const main = async () => {
     "update-city-boundaries",
     cityName,
     addFlag,
-    "Polygon",
     newCityProperties,
     "data/cities-polygons.geojson",
     "city-update.geojson"

--- a/scripts/update-lots.js
+++ b/scripts/update-lots.js
@@ -13,7 +13,6 @@ const main = async () => {
     "update-lots",
     cityName,
     addFlag,
-    "MultiPolygon",
     {},
     "data/parking-lots.geojson",
     "parking-lots-update.geojson"


### PR DESCRIPTION
The `update-city-boundaries` script failed when uploading the Birmingham data because it used `StraightLine` rather than `Polygon` like past entries. That caused Leaflet to fail to process the GeoJSON.

It doesn't matter which we use, as long as we respect the original data source. We already validate that there is only one `Feature`, which does matter.