### PR TITLE
Remove unused script and CSS loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,37 +72,15 @@
       integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
       crossorigin=""
     />
-    <link rel="stylesheet" href="src/css/vendor/bootstrap.css" />
-
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
-    <link
-      rel="stylesheet"
-      href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"
-    />
-    <link rel="stylesheet" href="src/css/vendor/leaflet.zoomhome.css" />
-    <link rel="stylesheet" href="src/css/style.css" />
-
     <script
       src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"
       integrity="sha512-nMMmRyTVoLYqjP9hrbed9S+FzjZHW5gY1TWCHA5ckwXZBadntCNs8kEqAWdrb9O7rxbCaA4lKTIWjDXZxflOcA=="
       crossorigin=""
     ></script>
+    <link rel="stylesheet" href="src/css/vendor/bootstrap.css" />
+    <link rel="stylesheet" href="src/css/vendor/leaflet.zoomhome.css" />
+    <link rel="stylesheet" href="src/css/style.css" />
     <script src="src/js/vendor/leaflet.zoomhome.js"></script>
-    <script
-      src="https://unpkg.com/esri-leaflet@2.3.0/dist/esri-leaflet.js"
-      integrity="sha512-1tScwpjXwwnm6tTva0l0/ZgM3rYNbdyMj5q6RSQMbNX6EUMhYDE3pMRGZaT41zHEvLoWEK7qFEJmZDOoDMU7/Q=="
-      crossorigin=""
-    ></script>
-
-    <link
-      rel="stylesheet"
-      href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css"
-      integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p"
-      crossorigin="anonymous"
-    />
   </head>
 
   <body>


### PR DESCRIPTION
These aren't used and slow down our site:

* leaflet.awesome-markers is only relevant if we use `L.awesomeMarkers`. We don't use anything like that.
* `font-awesome` is to load some icons, but we don't use any of them.
* `esri-leaflet.js` is an integration with ESRI that we don't use.