### PR TITLE
Upgrade Leaflet to 1.7.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,13 +68,13 @@
 
     <link
       rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css"
-      integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
+      href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+      integrity="sha256-BPfK9M5v34c2XP6p0cxVz1mUQLst0gTLk0mlc7kuodA="
       crossorigin=""
     />
     <script
-      src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"
-      integrity="sha512-nMMmRyTVoLYqjP9hrbed9S+FzjZHW5gY1TWCHA5ckwXZBadntCNs8kEqAWdrb9O7rxbCaA4lKTIWjDXZxflOcA=="
+      src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
+      integrity="sha256-yDc0eil8GjWFKqN1OSzHSVCiuGghTosZCcRje4tj7iQ="
       crossorigin=""
     ></script>
     <link


### PR DESCRIPTION
1.9.3 is arguably better, but it changes the font size for the control menu so https://github.com/ParkingReformNetwork/parking-lot-map/pull/46 is on hold until we decide the priority.

Meanwhile, we can get several years of improvements by going to 1.7.1, which renders the same as before.