### PR TITLE
Use continuous deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,3 +23,11 @@ jobs:
           sleep 8 # give server some time to start
       - name: Run tests on dist/
         run: npm run test-dist
+      - name: Deploy
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          key: ${{ secrets.SERVER_PRIVATE_KEY }}
+          source: dist/
+          target: /var/www/parkingreform.org/parking-lot-map/

--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ Regardless of whether what you updated, start the site with `npm start` and make
 
 Finally, save your changes in Git (in a new branch) and open a pull request. See the section "Make a contribution" below.
 
-## Build for a release
+## Build to preview a release
 
-```bash
-❯ npm run build
-```
+We use continuous deployment, meaning that we re-deploy the site every time we merge a pull request.
 
-Then copy the `dist/` folder to the server. We want to serve the file `dist/index.html`.
+You can preview what a build will look like by running `npm run build`. Then use `npm run serve-dist` to start the server.
+
+You can also run our integration tests on built dist folder. Run `npm run serve-dist` in one terminal, then `npm run test-dist` in another.
 
 ## Make a contribution
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "source": "index.html",
   "scripts": {
     "start": "parcel",
-    "build": "rm -rf dist; parcel build",
+    "build": "rm -rf dist; parcel build --detailed-report",
     "test": "jest",
     "fmt": "prettier --write .",
     "fix": "prettier --write scripts/ src/js/ src/tests; eslint --fix scripts/ src/",


### PR DESCRIPTION
We'll now deploy the site when landing every pull request.

This will make it easier for us to frequently improve the site, especially loading new data.

Crucial to this is that we have ample testing. We should continue expanding the testing as we discover new issues.