### PR TITLE
Switch to ES6 modules for `scripts/`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,3 +10,4 @@ parserOptions:
   sourceType: module
 rules:
   no-unexpected-multiline: off
+  import/extensions: off

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules/
 /.idea/
+/.fleet/
 /dist/
 /.parcel-cache/
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "parking-lot-map",
   "version": "1.0.0",
   "source": "index.html",
+  "type": "module",
   "scripts": {
     "start": "parcel",
     "build": "rm -rf dist; parcel build --detailed-report",

--- a/scripts/base.js
+++ b/scripts/base.js
@@ -1,4 +1,4 @@
-const fs = require("fs").promises;
+import fs from "fs/promises";
 
 // Rather than using `try/catch`, we return either `Ok` or `Err`.
 // This emulates Rust's `Result` type.
@@ -107,9 +107,4 @@ const updateCoordinates = async (
   return Ok("File updated successfully!");
 };
 
-module.exports = {
-  Ok,
-  Err,
-  determineArgs,
-  updateCoordinates,
-};
+export { Ok, Err, determineArgs, updateCoordinates };

--- a/scripts/update-city.js
+++ b/scripts/update-city.js
@@ -1,4 +1,4 @@
-const { determineArgs, updateCoordinates } = require("./base");
+import { determineArgs, updateCoordinates } from "./base.js";
 
 const main = async () => {
   const args = determineArgs("update-city-boundaries", process.argv.slice(2));
@@ -42,8 +42,4 @@ const main = async () => {
   /* eslint-enable no-console */
 };
 
-if (require.main === module) {
-  (async () => {
-    await main();
-  })();
-}
+main();

--- a/scripts/update-lots.js
+++ b/scripts/update-lots.js
@@ -1,4 +1,4 @@
-const { determineArgs, updateCoordinates } = require("./base");
+import { determineArgs, updateCoordinates } from "./base.js";
 
 const main = async () => {
   const args = determineArgs("update-lots", process.argv.slice(2));
@@ -32,8 +32,4 @@ const main = async () => {
   /* eslint-enable no-console */
 };
 
-if (require.main === module) {
-  (async () => {
-    await main();
-  })();
-}
+main();


### PR DESCRIPTION
This allows us to import from `src/js`.

Prework for https://github.com/ParkingReformNetwork/parking-lot-map/issues/62.