### PR TITLE
Store city ID in GeoJSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then, save your changes in Git (in a new branch) and open a pull request. See th
 
 ## Update city score card and boundaries
 
-Directly edit the score card in `data/cities-polygons.geojson`. Search for your city name, like `Saint Louis, Mo`. Be careful to not change the key names.
+To change the score card, directly edit it in `data/cities-polygons.geojson`. Search for your city name, like `Saint Louis, Mo`. Be careful to not change the key names.
 
 To update the boundaries, export the geoJSON file and save it as the file `city-update.geojson` in the root of this repository. If the file already exists, overwrite it with your new data.
 

--- a/data/cities-polygons.geojson
+++ b/data/cities-polygons.geojson
@@ -11,6 +11,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "anaheim-ca",
         "Name": "Anaheim, CA",
         "Percentage": "23%",
         "Population": "346,824",
@@ -43,6 +44,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "anchorage-ak",
         "Name": "Anchorage, AK",
         "Percentage": "30%",
         "Population": "291,247",
@@ -96,6 +98,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "arlington-tx",
         "Name": "Arlington, TX",
         "Percentage": "42%",
         "Population": "394,218",
@@ -130,6 +133,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "atlanta-ga",
         "Name": "Atlanta, GA",
         "Percentage": "25%",
         "Population": "386,241",
@@ -215,6 +219,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "austin-tx",
         "Name": "Austin, TX",
         "Percentage": "17%",
         "Population": "959,549",
@@ -271,6 +276,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "baltimore-md",
         "Name": "Baltimore, MD",
         "Percentage": "11%",
         "Population": "585,708",
@@ -382,6 +388,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "boston-ma",
         "Name": "Boston, MA",
         "Percentage": "6%",
         "Population": "676,216",
@@ -901,6 +908,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "charlotte-nc",
         "Name": "Charlotte, NC",
         "Percentage": "18%",
         "Population": "874,541",
@@ -938,6 +946,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "chicago-il",
         "Name": "Chicago, IL",
         "Percentage": "4%",
         "Population": "2,747,231",
@@ -1023,6 +1032,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "cincinnati-oh",
         "Name": "Cincinnati, OH",
         "Percentage": "21%",
         "Population": "309,317",
@@ -1085,6 +1095,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "cleveland-oh",
         "Name": "Cleveland, OH",
         "Percentage": "26%",
         "Population": "373,091",
@@ -1187,6 +1198,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "columbus-oh",
         "Name": "Columbus, OH",
         "Percentage": "27%",
         "Population": "905,672",
@@ -1342,6 +1354,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "dallas-tx",
         "Name": "Dallas, TX",
         "Percentage": "24%",
         "Population": "1,304,442",
@@ -1448,6 +1461,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "denver-co",
         "Name": "Denver, CO",
         "Percentage": "11%",
         "Population": "715,522",
@@ -1515,6 +1529,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "detroit-mi",
         "Name": "Detroit, MI",
         "Percentage": "30%",
         "Population": "639,614",
@@ -1587,6 +1602,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "fort-worth-tx",
         "Name": "Fort Worth, TX",
         "Percentage": "27%",
         "Population": "918,377",
@@ -1690,6 +1706,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "honolulu-hi",
         "Name": "Honolulu, HI",
         "Percentage": "15%",
         "Population": "350,964",
@@ -1763,6 +1780,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "houston-tx",
         "Name": "Houston, TX",
         "Percentage": "26%",
         "Population": "2,302,792",
@@ -1902,6 +1920,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "jersey-city-nj",
         "Name": "Jersey City, NJ",
         "Percentage": "20%",
         "Population": "292,449",
@@ -2122,6 +2141,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "kansas-city-mo",
         "Name": "Kansas City, MO",
         "Percentage": "29%",
         "Population": "507,969",
@@ -2201,6 +2221,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "las-vegas-nv",
         "Name": "Las Vegas, NV",
         "Percentage": "32%",
         "Population": "641,825",
@@ -2251,6 +2272,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "long-beach-ca",
         "Name": "Long Beach, CA",
         "Percentage": "18%",
         "Population": "466,302",
@@ -2369,6 +2391,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "los-angeles-ca",
         "Name": "Los Angeles, CA",
         "Percentage": "12%",
         "Population": "3,893,986",
@@ -2410,6 +2433,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "louisville-ky",
         "Name": "Louisville, KY",
         "Percentage": "28%",
         "Population": "632,689",
@@ -2513,6 +2537,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "lubbock-tx",
         "Name": "Lubbock, TX",
         "Percentage": "35%",
         "Population": "257,141",
@@ -2546,6 +2571,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "mesa-az",
         "Name": "Mesa, AZ",
         "Percentage": "32%",
         "Population": "504,500",
@@ -2571,6 +2597,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "miami-fl",
         "Name": "Miami, FL",
         "Percentage": "17%",
         "Population": "442,265",
@@ -2664,6 +2691,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "minneapolis-mn",
         "Name": "Minneapolis, MN",
         "Percentage": "18%",
         "Population": "428,403",
@@ -2728,6 +2756,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "nashville-tn",
         "Name": "Nashville, TN",
         "Percentage": "18%",
         "Population": "689,504",
@@ -2815,6 +2844,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "new-orleans-la",
         "Name": "New Orleans, LA",
         "Percentage": "18%",
         "Population": "383,997",
@@ -2879,6 +2909,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "new-york-ny",
         "Name": "New York, NY",
         "Percentage": "1%",
         "Population": "8,804,190",
@@ -2903,6 +2934,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "newark-nj",
         "Name": "Newark, NJ",
         "Percentage": "24%",
         "Population": "311,549",
@@ -2950,6 +2982,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "oakland-ca",
         "Name": "Oakland, CA",
         "Percentage": "12%",
         "Population": "439,349",
@@ -3081,6 +3114,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "orlando-fl",
         "Name": "Orlando, FL",
         "Percentage": "29%",
         "Population": "307,573",
@@ -3180,6 +3214,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "philadelphia-pa",
         "Name": "Philadelphia, PA",
         "Percentage": "13%",
         "Population": "1,603,797",
@@ -3212,6 +3247,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "phoenix-az",
         "Name": "Phoenix, AZ",
         "Percentage": "20%",
         "Population": "1,607,739",
@@ -3243,6 +3279,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "pittsburgh-pa",
         "Name": "Pittsburgh, PA",
         "Percentage": "18%",
         "Population": "302,971",
@@ -3323,6 +3360,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "portland-or",
         "Name": "Portland, OR",
         "Percentage": "11%",
         "Population": "652,089",
@@ -3432,6 +3470,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "riverside-ca",
         "Name": "Riverside, CA",
         "Percentage": "34%",
         "Population": "317,610",
@@ -3472,6 +3511,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "sacramento-ca",
         "Name": "Sacramento, CA",
         "Percentage": "16%",
         "Population": "522,754",
@@ -3524,6 +3564,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "saint-louis-mo",
         "Name": "Saint Louis, MO",
         "Percentage": "21%",
         "Population": "301,578",
@@ -3561,6 +3602,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "saint-paul-mn",
         "Name": "Saint Paul, MN",
         "Percentage": "16%",
         "Population": "311,527",
@@ -3638,6 +3680,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "san-antonio",
         "Name": "San Antonio",
         "Percentage": "26%",
         "Population": "1,434,270",
@@ -3749,6 +3792,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "san-diego-ca",
         "Name": "San Diego, CA",
         "Percentage": "14%",
         "Population": "1,385,922",
@@ -3845,6 +3889,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "san-francisco-ca",
         "Name": "San Francisco, CA",
         "Percentage": "4%",
         "Population": "873,965",
@@ -3908,6 +3953,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "san-jose-ca",
         "Name": "San Jose, CA",
         "Percentage": "14%",
         "Population": "1,014,545",
@@ -3999,6 +4045,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "seattle-wa",
         "Name": "Seattle, WA",
         "Percentage": "10%",
         "Population": "735,157",
@@ -4077,6 +4124,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "tulsa-ok",
         "Name": "Tulsa, OK",
         "Percentage": "28%",
         "Population": "413,066",
@@ -4177,6 +4225,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "washington-dc",
         "Name": "Washington, DC",
         "Percentage": "3%",
         "Population": "689,545",
@@ -4207,6 +4256,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "tampa-fl",
         "Name": "Tampa, FL",
         "Percentage": "30%",
         "Population": "382,769",
@@ -4284,6 +4334,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "indianapolis-in",
         "Name": "Indianapolis, IN",
         "Percentage": "25%",
         "Population": "887,752",
@@ -4308,6 +4359,7 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "birmingham-al",
         "Name": "Birmingham, AL",
         "Percentage": "26%",
         "Population": "200,733",

--- a/data/parking-lots.geojson
+++ b/data/parking-lots.geojson
@@ -11,7 +11,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Honolulu, HI"
+        "id": "honolulu-hi"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1697,7 +1697,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Mesa, AZ"
+        "id": "mesa-az"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2739,7 +2739,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Minneapolis, MN"
+        "id": "minneapolis-mn"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -3934,7 +3934,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Anaheim, CA"
+        "id": "anaheim-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -5018,7 +5018,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Anchorage, AK"
+        "id": "anchorage-ak"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -7486,7 +7486,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Arlington, TX"
+        "id": "arlington-tx"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -10461,7 +10461,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Atlanta, GA"
+        "id": "atlanta-ga"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -12866,7 +12866,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Austin, TX"
+        "id": "austin-tx"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -16475,7 +16475,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Baltimore, MD"
+        "id": "baltimore-md"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -17625,7 +17625,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Boston, MA"
+        "id": "boston-ma"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -19326,7 +19326,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Charlotte, NC"
+        "id": "charlotte-nc"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -20175,7 +20175,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Chicago, IL"
+        "id": "chicago-il"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -20578,7 +20578,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Cincinnati, OH"
+        "id": "cincinnati-oh"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -22222,7 +22222,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Cleveland, OH"
+        "id": "cleveland-oh"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -24833,7 +24833,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Columbus, OH"
+        "id": "columbus-oh"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -29629,7 +29629,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Dallas, TX"
+        "id": "dallas-tx"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -31841,7 +31841,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Denver, CO"
+        "id": "denver-co"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -32890,7 +32890,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Detroit, MI"
+        "id": "detroit-mi"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -35148,7 +35148,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Fort Worth, TX"
+        "id": "fort-worth-tx"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -36961,7 +36961,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Houston, TX"
+        "id": "houston-tx"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -39132,7 +39132,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Indianapolis, IN"
+        "id": "indianapolis-in"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -41275,7 +41275,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Jersey City, NJ"
+        "id": "jersey-city-nj"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -42327,7 +42327,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Kansas City, MO"
+        "id": "kansas-city-mo"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -44409,7 +44409,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Las Vegas, NV"
+        "id": "las-vegas-nv"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -47878,7 +47878,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Long Beach, CA"
+        "id": "long-beach-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -49310,7 +49310,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Los Angeles, CA"
+        "id": "los-angeles-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -50528,7 +50528,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Louisville, KY"
+        "id": "louisville-ky"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -54472,7 +54472,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Lubbock, TX"
+        "id": "lubbock-tx"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -57016,7 +57016,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Miami, FL"
+        "id": "miami-fl"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -59124,7 +59124,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Nashville, TN"
+        "id": "nashville-tn"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -60369,7 +60369,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "New Orleans, LA"
+        "id": "new-orleans-la"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -63318,7 +63318,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "New York, NY"
+        "id": "new-york-ny"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -63579,7 +63579,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Newark, NJ"
+        "id": "newark-nj"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -65026,7 +65026,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Oakland, CA"
+        "id": "oakland-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -67378,7 +67378,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Orlando, FL"
+        "id": "orlando-fl"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -68597,7 +68597,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Philadelphia, PA"
+        "id": "philadelphia-pa"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -70279,7 +70279,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Phoenix, AZ"
+        "id": "phoenix-az"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -74312,7 +74312,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Pittsburgh, PA"
+        "id": "pittsburgh-pa"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -75458,7 +75458,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Portland, OR"
+        "id": "portland-or"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -77092,7 +77092,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Riverside, CA"
+        "id": "riverside-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -78690,7 +78690,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Sacramento, CA"
+        "id": "sacramento-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -80449,7 +80449,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Saint Paul, MN"
+        "id": "saint-paul-mn"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -81853,7 +81853,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "San Antonio"
+        "id": "san-antonio"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -85646,7 +85646,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "San Diego, CA"
+        "id": "san-diego-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -87274,7 +87274,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "San Francisco, CA"
+        "id": "san-francisco-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -87876,7 +87876,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "San Jose, CA"
+        "id": "san-jose-ca"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -89209,7 +89209,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Seattle, WA"
+        "id": "seattle-wa"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -90590,7 +90590,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Saint Louis, MO"
+        "id": "saint-louis-mo"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -92257,7 +92257,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Tulsa, OK"
+        "id": "tulsa-ok"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -95129,7 +95129,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Tampa, FL"
+        "id": "tampa-fl"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -97038,7 +97038,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Washington, DC"
+        "id": "washington-dc"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -99506,7 +99506,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Birmingham, AL"
+        "id": "birmingham-al"
       },
       "geometry": {
         "type": "MultiPolygon",

--- a/scripts/base.js
+++ b/scripts/base.js
@@ -1,4 +1,5 @@
 import fs from "fs/promises";
+import { parseCityIdFromJson } from "../src/js/cityId.js";
 
 // Rather than using `try/catch`, we return either `Ok` or `Err`.
 // This emulates Rust's `Result` type.
@@ -6,7 +7,7 @@ const Ok = (value) => ({ value });
 const Err = (error) => ({ error });
 
 /**
- * Determine the city name and if `--add` was set.
+ * Determine the city name, city ID, and if `--add` was set.
  *
  * @param string scriptCommand - i.e. `update-lots` or `update-city-boundaries`.
  * @param list[string] processArgv - all argv after the first two elements.
@@ -31,14 +32,15 @@ const determineArgs = (scriptCommand, processArgv) => {
     );
   }
 
-  return Ok({ cityName, addFlag });
+  const cityId = parseCityIdFromJson(cityName);
+  return Ok({ cityName, cityId, addFlag });
 };
 
 /**
- * Rewrite the coordinates for `cityName`.
+ * Rewrite the coordinates for `cityId`.
  *
  * @param string scriptCommand - i.e. `update-lots` or `update-city-boundaries`.
- * @param string cityName - e.g. 'My City, AZ'
+ * @param string cityId - e.g. 'my-city-az'
  * @param boolean addCity - what to do if the city is missing
  * @param object additionalPropertiesForNewCity - any additional keys and filler values to add
       to Properties when creating a new city.
@@ -49,7 +51,7 @@ const determineArgs = (scriptCommand, processArgv) => {
  */
 const updateCoordinates = async (
   scriptCommand,
-  cityName,
+  cityId,
   addCity,
   additionalPropertiesForNewCity,
   originalFilePath,
@@ -87,17 +89,17 @@ const updateCoordinates = async (
   if (addCity) {
     const newEntry = {
       type: "Feature",
-      properties: { Name: cityName, ...additionalPropertiesForNewCity },
+      properties: { id: cityId, ...additionalPropertiesForNewCity },
       geometry: { type: newGeometryType, coordinates: newCoordinates },
     };
     originalData.features.push(newEntry);
   } else {
     const cityOriginalData = originalData.features.find(
-      (feature) => feature.properties.Name === cityName
+      (feature) => feature.properties.id === cityId
     );
     if (!cityOriginalData) {
       return Err(
-        `City not found in ${originalFilePath}. To add a new city, run again with the '--add' flag, e.g. npm run ${scriptCommand} -- '${cityName}' --add`
+        `City not found in ${originalFilePath}. To add a new city, run again with the '--add' flag, e.g. npm run ${scriptCommand} -- 'My City, AZ' --add`
       );
     }
     cityOriginalData.geometry.coordinates = newCoordinates;

--- a/scripts/tests/base.test.js
+++ b/scripts/tests/base.test.js
@@ -11,13 +11,25 @@ const { determineArgs, updateCoordinates } = require("../base");
 describe("determineArgs()", () => {
   test("detects whether --add is set", () => {
     let result = determineArgs("my-script", ["My City"]);
-    expect(result.value).toEqual({ cityName: "My City", addFlag: false });
+    expect(result.value).toEqual({
+      cityName: "My City",
+      cityId: "my-city",
+      addFlag: false,
+    });
 
     result = determineArgs("my-script", ["My City", "--add"]);
-    expect(result.value).toEqual({ cityName: "My City", addFlag: true });
+    expect(result.value).toEqual({
+      cityName: "My City",
+      cityId: "my-city",
+      addFlag: true,
+    });
 
     result = determineArgs("my-script", ["--add", "My City"]);
-    expect(result.value).toEqual({ cityName: "My City", addFlag: true });
+    expect(result.value).toEqual({
+      cityName: "My City",
+      cityId: "my-city",
+      addFlag: true,
+    });
   });
 
   test("requires the city to be specified", () => {
@@ -55,10 +67,10 @@ describe("updateCoordinates()", () => {
   test("updates the coordinates for an existing city", async () => {
     const updateFilePath = validUpdateFilePath;
 
-    const cityName = "Shoup Ville, AZ";
+    const cityId = "shoup-ville-az";
     const result = await updateCoordinates(
       "my-script",
-      cityName,
+      cityId,
       false,
       {},
       originalFilePath,
@@ -75,7 +87,7 @@ describe("updateCoordinates()", () => {
     const resultData = JSON.parse(rawResultData);
 
     const cityTargetData = resultData.features.find(
-      (feature) => feature.properties.Name === cityName
+      (feature) => feature.properties.id === cityId
     );
     expect(cityTargetData.geometry.coordinates).toEqual(updatedCoordinates);
   });
@@ -83,10 +95,10 @@ describe("updateCoordinates()", () => {
   test("adds a new city when `--add` used", async () => {
     const updateFilePath = validUpdateFilePath;
 
-    const cityName = "Parking Reform Now, NY";
+    const cityId = "parking-reform-now";
     const result = await updateCoordinates(
       "my-script",
-      cityName,
+      cityId,
       true,
       { MyProperty: "Fill me in" },
       originalFilePath,
@@ -103,10 +115,10 @@ describe("updateCoordinates()", () => {
     const resultData = JSON.parse(rawResultData);
 
     const cityTargetData = resultData.features.find(
-      (feature) => feature.properties.Name === cityName
+      (feature) => feature.properties.id === cityId
     );
     expect(cityTargetData.properties).toEqual({
-      Name: cityName,
+      id: cityId,
       MyProperty: "Fill me in",
     });
     expect(cityTargetData.geometry.type).toEqual("MultiPolygon");
@@ -116,7 +128,7 @@ describe("updateCoordinates()", () => {
   test("errors if city cannot be found in the original data and `--add` not set", async () => {
     const result = await updateCoordinates(
       "my-script",
-      "Bad City",
+      "bad-city",
       false,
       {},
       originalFilePath,
@@ -128,7 +140,7 @@ describe("updateCoordinates()", () => {
   test("validates the update file has exactly one `feature`", async () => {
     let result = await updateCoordinates(
       "my-script",
-      "Shoup Ville, AZ",
+      "shoup-ville-az",
       false,
       {},
       originalFilePath,
@@ -138,7 +150,7 @@ describe("updateCoordinates()", () => {
 
     result = await updateCoordinates(
       "my-script",
-      "Shoup Ville, AZ",
+      "shoup-ville-az",
       false,
       {},
       originalFilePath,
@@ -150,7 +162,7 @@ describe("updateCoordinates()", () => {
   test("errors gracefully if update file not found", async () => {
     const result = await updateCoordinates(
       "my-script",
-      "Shoup Ville, AZ",
+      "shoup-ville-az",
       false,
       {},
       originalFilePath,
@@ -162,7 +174,7 @@ describe("updateCoordinates()", () => {
   test("errors gracefully if original data file not found", async () => {
     const result = await updateCoordinates(
       "my-script",
-      "Shoup Ville, AZ",
+      "shoup-ville-az",
       false,
       {},
       "scripts/tests/data/does-not-exist",

--- a/scripts/tests/data/original-data.geojson
+++ b/scripts/tests/data/original-data.geojson
@@ -11,7 +11,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Honolulu, HI"
+        "id": "honolulu-hi"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -28,7 +28,7 @@
     {
       "type": "Feature",
       "properties": {
-        "Name": "Shoup Ville, AZ"
+        "id": "shoup-ville-az"
       },
       "geometry": {
         "type": "MultiPolygon",

--- a/scripts/update-city.js
+++ b/scripts/update-city.js
@@ -8,8 +8,9 @@ const main = async () => {
     process.exit(1);
   }
 
-  const { cityName, addFlag } = args.value;
+  const { cityName, cityId, addFlag } = args.value;
   const newCityProperties = {
+    Name: cityName,
     Percentage: "FILL ME IN, e.g. 23%",
     Population: "FILL ME IN, e.g. 346,824",
     "Metro Population": "FILL ME IN, e.g. 13,200,998",
@@ -19,7 +20,7 @@ const main = async () => {
   };
   const result = await updateCoordinates(
     "update-city-boundaries",
-    cityName,
+    cityId,
     addFlag,
     newCityProperties,
     "data/cities-polygons.geojson",

--- a/scripts/update-lots.js
+++ b/scripts/update-lots.js
@@ -8,10 +8,10 @@ const main = async () => {
     process.exit(1);
   }
 
-  const { cityName, addFlag } = args.value;
+  const { cityId, addFlag } = args.value;
   const result = await updateCoordinates(
     "update-lots",
-    cityName,
+    cityId,
     addFlag,
     {},
     "data/parking-lots.geojson",

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -1,11 +1,7 @@
 import * as L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
-import {
-  determineShareUrl,
-  extractCityIdFromUrl,
-  parseCityIdFromJson,
-} from "./cityId";
+import { determineShareUrl, extractCityIdFromUrl } from "./cityId";
 import { createZoomHome } from "./vendor/leaflet.zoomhome";
 import citiesData from "../../data/cities-polygons.geojson";
 import parkingLotsData from "../../data/parking-lots.geojson";
@@ -178,7 +174,6 @@ const generateScorecard = (cityProperties) => {
  * @param windowUrl: The `window.location.href` global
  * @param leaflet: The `L` global
  * @param map: The Leaflet map instance.
- * @param string cityId: e.g. `saint-louis-mo`
  * @param cityProperties: An object with a `layout` key (Leaflet value) and keys
  *    representing the score card properties stored in the Geojson files.
  */
@@ -187,13 +182,12 @@ const setMapToCity = (
   windowUrl,
   leaflet,
   map,
-  cityId,
   cityProperties
 ) => {
   const { layer } = cityProperties;
   map.fitBounds(layer.getBounds());
   const scorecard = generateScorecard(cityProperties);
-  setUpShareUrlClickListener(docObj, windowUrl, cityId);
+  setUpShareUrlClickListener(docObj, windowUrl, cityProperties.id);
   const popup = leaflet
     .popup({
       pane: "fixed",
@@ -223,8 +217,7 @@ const setUpCitiesLayer = (docObj, windowUrl, leaflet, map, initialCityId) => {
         return citiesPolygonsStyle;
       },
       onEachFeature(feature, layer) {
-        const key = parseCityIdFromJson(feature.properties.Name);
-        cities[key] = { layer, ...feature.properties };
+        cities[feature.properties.id] = { layer, ...feature.properties };
       },
     })
     .addTo(map);
@@ -233,10 +226,10 @@ const setUpCitiesLayer = (docObj, windowUrl, leaflet, map, initialCityId) => {
   const cityToggleElement = docObj.getElementById("city-choice");
   cityToggleElement.addEventListener("change", () => {
     const cityId = cityToggleElement.value;
-    setMapToCity(docObj, windowUrl, leaflet, map, cityId, cities[cityId]);
+    setMapToCity(docObj, windowUrl, leaflet, map, cities[cityId]);
   });
 
-  // Add each city to the city selection toggle and set the initial city.
+  // Add each city to the city selection toggle.
   const cityKeys = Object.keys(cities).sort();
   cityKeys.forEach((key) => {
     const option = docObj.createElement("option");
@@ -249,14 +242,7 @@ const setUpCitiesLayer = (docObj, windowUrl, leaflet, map, initialCityId) => {
   const validatedInitialCityId =
     initialCityId in cities ? initialCityId : "columbus-oh";
   cityToggleElement.value = validatedInitialCityId;
-  setMapToCity(
-    docObj,
-    windowUrl,
-    leaflet,
-    map,
-    validatedInitialCityId,
-    cities[validatedInitialCityId]
-  );
+  setMapToCity(docObj, windowUrl, leaflet, map, cities[validatedInitialCityId]);
 };
 
 /**

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -177,13 +177,7 @@ const generateScorecard = (cityProperties) => {
  * @param cityProperties: An object with a `layout` key (Leaflet value) and keys
  *    representing the score card properties stored in the Geojson files.
  */
-const setMapToCity = (
-  docObj,
-  windowUrl,
-  leaflet,
-  map,
-  cityProperties
-) => {
+const setMapToCity = (docObj, windowUrl, leaflet, map, cityProperties) => {
   const { layer } = cityProperties;
   map.fitBounds(layer.getBounds());
   const scorecard = generateScorecard(cityProperties);

--- a/src/tests/cityId.test.js
+++ b/src/tests/cityId.test.js
@@ -41,6 +41,7 @@ test("parseCityIdFromJson() extracts the city", () => {
   expect(parseCityIdFromJson("Saint Shoup Village, AZ")).toEqual(
     "saint-shoup-village-az"
   );
+  expect(parseCityIdFromJson("No state")).toEqual("no-state");
 });
 
 describe("determineShareUrl()", () => {


### PR DESCRIPTION
Part of https://github.com/ParkingReformNetwork/parking-lot-map/issues/62.

In a follow up, we can sort the GeoJson files. Then, that will allow us to set up the city toggle before loading the map and avoid sorting inside the script.