### PR TITLE
Remove "Select a city" option from city toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,9 +80,7 @@
   <body>
     <fieldset id="tier-dropdown">
       <label for="city-choice">Select a city: </label>
-      <select name="city-choice" id="city-choice">
-        <option value="ALL">Select a city</option>
-      </select>
+      <select name="city-choice" id="city-choice"></select>
     </fieldset>
 
     <div class="banners">

--- a/src/tests/setUpSite.test.js
+++ b/src/tests/setUpSite.test.js
@@ -82,7 +82,6 @@ test("every city is in the toggle", async () => {
   await page.close();
 
   expectedCities.sort();
-  expectedCities.splice(0, 0, "Select a city");
   expect(toggleValues).toEqual(expectedCities);
 });
 


### PR DESCRIPTION
This option was confusing once the site loads. It didn't actually work, and its semantics are unclear anyways.

It's somewhat useful when the site is first loading, but we set up the city toggle so fast (especially after https://github.com/ParkingReformNetwork/parking-lot-map/pull/71) that it doesn't matter. It's fine to show an empty select box for a couple of milliseconds.