### PR TITLE
Modernize and ESLint zoomhome.js

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,8 +2,6 @@ extends:
   - eslint:recommended
   - airbnb-base
   - prettier
-ignorePatterns:
-  - "**/vendor/*.js"
 overrides: []
 parserOptions:
   ecmaVersion: latest

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist; parcel build --detailed-report",
     "test": "jest",
     "fmt": "prettier --write .",
-    "fix": "prettier --write scripts/ src/js/ src/tests; eslint --fix scripts/ src/",
+    "fix": "prettier --write scripts/ src/; eslint --fix scripts/ src/",
     "lint": "prettier --check . && eslint scripts/ src/",
     "update-city-boundaries": "node scripts/update-city.js",
     "update-lots": "node scripts/update-lots.js",

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -3,7 +3,7 @@ import * as L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
 import { determineShareUrl, extractCityIdFromUrl } from "./cityId";
-import { createZoomHome } from "./vendor/leaflet.zoomhome";
+import createZoomHome from "./vendor/leaflet.zoomhome";
 import citiesData from "../../data/cities-polygons.geojson";
 import parkingLotsData from "../../data/parking-lots.geojson";
 

--- a/src/js/vendor/leaflet.zoomhome.js
+++ b/src/js/vendor/leaflet.zoomhome.js
@@ -7,6 +7,8 @@
  * Based on code by toms (https://gis.stackexchange.com/a/127383/48264).
  */
 
+/* eslint-disable no-underscore-dangle, no-param-reassign */
+
 import * as L from "leaflet";
 
 L.Control.ZoomHome = L.Control.Zoom.extend({
@@ -22,10 +24,10 @@ L.Control.ZoomHome = L.Control.Zoom.extend({
     homeZoom: null,
   },
 
-  onAdd: function (map) {
-    var controlName = "leaflet-control-zoomhome",
-      container = L.DomUtil.create("div", controlName + " leaflet-bar"),
-      options = this.options;
+  onAdd(map) {
+    const controlName = "leaflet-control-zoomhome";
+    const container = L.DomUtil.create("div", `${controlName} leaflet-bar`);
+    const { options } = this;
 
     if (options.homeCoordinates === null) {
       options.homeCoordinates = map.getCenter();
@@ -37,25 +39,22 @@ L.Control.ZoomHome = L.Control.Zoom.extend({
     this._zoomInButton = this._createButton(
       options.zoomInText,
       options.zoomInTitle,
-      controlName + "-in",
+      `${controlName}-in`,
       container,
       this._zoomIn.bind(this)
     );
-    var zoomHomeText =
-      '<i class="fa fa-' +
-      options.zoomHomeIcon +
-      '" style="line-height:1.65;"></i>';
+    const zoomHomeText = `<i class="fa fa-${options.zoomHomeIcon}" style="line-height:1.65;"></i>`;
     this._zoomHomeButton = this._createButton(
       zoomHomeText,
       options.zoomHomeTitle,
-      controlName + "-home",
+      `${controlName}-home`,
       container,
       this._zoomHome.bind(this)
     );
     this._zoomOutButton = this._createButton(
       options.zoomOutText,
       options.zoomOutTitle,
-      controlName + "-out",
+      `${controlName}-out`,
       container,
       this._zoomOut.bind(this)
     );
@@ -66,48 +65,43 @@ L.Control.ZoomHome = L.Control.Zoom.extend({
     return container;
   },
 
-  setHomeBounds: function (bounds) {
+  setHomeBounds(bounds) {
     if (bounds === undefined) {
       bounds = this._map.getBounds();
-    } else {
-      if (typeof bounds.getCenter !== "function") {
-        bounds = L.latLngBounds(bounds);
-      }
+    } else if (typeof bounds.getCenter !== "function") {
+      bounds = L.latLngBounds(bounds);
     }
     this.options.homeZoom = this._map.getBoundsZoom(bounds);
     this.options.homeCoordinates = bounds.getCenter();
   },
 
-  setHomeCoordinates: function (coordinates) {
+  setHomeCoordinates(coordinates) {
     if (coordinates === undefined) {
       coordinates = this._map.getCenter();
     }
     this.options.homeCoordinates = coordinates;
   },
 
-  setHomeZoom: function (zoom) {
+  setHomeZoom(zoom) {
     if (zoom === undefined) {
       zoom = this._map.getZoom();
     }
     this.options.homeZoom = zoom;
   },
 
-  getHomeZoom: function () {
+  getHomeZoom() {
     return this.options.homeZoom;
   },
 
-  getHomeCoordinates: function () {
+  getHomeCoordinates() {
     return this.options.homeCoordinates;
   },
 
-  _zoomHome: function (e) {
-    //jshint unused:false
+  _zoomHome() {
     this._map.setView(this.options.homeCoordinates, this.options.homeZoom);
   },
 });
 
-const createZoomHome = (options) => {
-  return new L.Control.ZoomHome(options);
-};
+const createZoomHome = (options) => new L.Control.ZoomHome(options);
 
-export { createZoomHome };
+export default createZoomHome;


### PR DESCRIPTION
No manual changes were made, other than using `export default`. I ignored anything requiring manual changes.

This makes the code easier to understand and is prework to stop using the global `L`.