### PR TITLE
Only load the Font Awesome icons we actually use

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,12 +66,6 @@
       content='Background image is a map showing where the parking lots are in Columbus. The banner Reads "PARKING LOT MAPS" and has a logo for the Parking Reform Network in the corner.'
     />
 
-    <link
-      rel="stylesheet"
-      href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css"
-      integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p"
-      crossorigin="anonymous"
-    />
     <link rel="stylesheet" href="src/css/vendor/bootstrap.css" />
     <link rel="stylesheet" href="src/css/vendor/leaflet.zoomhome.css" />
     <link rel="stylesheet" href="src/css/style.css" />
@@ -87,10 +81,10 @@
       <div class="banner-title">Parking Lot Map</div>
 
       <div class="banner-about">
-        <i class="expand-icon fas fa-info-circle" title="View fullscreen"></i>
+        <i class="expand-icon fa-solid fa-circle-info" title="About"></i>
         <a href="https://parkingreform.org/parking-lot-map/">
           <i
-            class="expand-icon fas fa-external-link-alt"
+            class="expand-icon fa-solid fa-up-right-from-square"
             title="View fullscreen"
           ></i>
         </a>
@@ -101,7 +95,7 @@
       <div class="about-text-container">
         <div class="about-close">
           <i
-            class="close-icon fas fa-circle-xmark"
+            class="close-icon fa-solid fa-circle-xmark"
             title="Close fullscreen"
           ></i>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "parking-lot-map",
       "version": "1.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.4.0",
+        "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "leaflet": "~1.7.1"
       },
       "devDependencies": {
@@ -1960,6 +1962,39 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test-dist": "PORT=8080 jest setUpSite"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.4.0",
+    "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "leaflet": "~1.7.1"
   },
   "devDependencies": {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -85,6 +85,7 @@ div.leaflet-popup-content-wrapper > div > div.title {
   display: inline-block;
   width: 50%;
 }
+
 div.leaflet-popup-content-wrapper > div > div.url-copy-button {
   float: right;
   width: 0%;
@@ -94,8 +95,8 @@ div.leaflet-popup-content-wrapper > div > div.url-copy-button:hover {
   cursor: pointer;
 }
 
-div.leaflet-popup-content-wrapper > div > div.url-copy-button > a > img {
-  width: 20px;
+div.leaflet-popup-content-wrapper > div > div.url-copy-button svg.fa-link {
+  color: #21ccb9;
 }
 
 div.popup-button a {
@@ -137,6 +138,16 @@ div.banner-about {
   background-color: #4d4d4d;
   color: #ffffff;
   float: right;
+  right: 2px;
+  cursor: pointer;
+}
+
+div.banner-about svg {
+  color: #ffffff;
+}
+
+div.banner-about svg.fa-circle-info {
+  margin-right: 10px;
 }
 
 #tier-dropdown label {
@@ -153,11 +164,6 @@ div.banner-title {
   float: left;
 }
 
-div.banner-about {
-  right: 2px;
-  cursor: pointer;
-}
-
 div.about-text-popup {
   position: absolute;
   z-index: 2001;
@@ -170,6 +176,10 @@ div.about-text-popup {
   width: 80%;
   top: 120px;
   overflow: auto;
+}
+
+div.about-text-popup svg.fa-circle-xmark {
+  color: #4d4d4d;
 }
 
 div.about-text-container {
@@ -235,27 +245,6 @@ div.donate-button a img {
 
 hr {
   margin: 10px 0;
-}
-
-.fa,
-.fas {
-  font-family: "Font Awesome 5 Pro";
-  font-weight: 900;
-}
-
-.fa-info-circle:before {
-  content: "\f05a";
-  margin-right: 10px;
-}
-
-.fa-external-link-alt:before {
-  content: "\f35d";
-  color: #fff;
-}
-
-.fa-circle-xmark:before {
-  content: "\f057";
-  color: #4d4d4d;
 }
 
 /* responsiveness of the popup */

--- a/src/js/fontAwesome.js
+++ b/src/js/fontAwesome.js
@@ -1,0 +1,16 @@
+import { library, dom } from "@fortawesome/fontawesome-svg-core";
+import {
+  faHome,
+  faLink,
+  faCircleInfo,
+  faCircleXmark,
+  faUpRightFromSquare,
+} from "@fortawesome/free-solid-svg-icons";
+import "@fortawesome/fontawesome-svg-core/styles.css";
+
+const setUpIcons = () => {
+  library.add(faCircleInfo, faCircleXmark, faHome, faLink, faUpRightFromSquare);
+  dom.watch();
+};
+
+export default setUpIcons;

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -3,6 +3,7 @@ import { Control, Map, Popup, TileLayer, geoJSON } from "leaflet";
 import "leaflet/dist/leaflet.css";
 
 import { determineShareUrl, extractCityIdFromUrl } from "./cityId";
+import setUpIcons from "./fontAwesome";
 import ZoomHome from "./vendor/leaflet.zoomhome";
 import citiesData from "../../data/cities-polygons.geojson";
 import parkingLotsData from "../../data/parking-lots.geojson";
@@ -159,7 +160,7 @@ const generateScorecard = (cityProperties) => {
   } = cityProperties;
   let result = `
     <div class="title">${Name}</div>
-    <div class="url-copy-button"><a href="#"><i class="fas fa-link fa-lg" style="color: #21ccb9;"></i></a></div>
+    <div class="url-copy-button"><a href="#"><i class="fa-solid fa-link fa-lg" style="color: #21ccb9;"></i></a></div>
     <hr>
     <div><span class="details-title">Percent of Central City Devoted to Parking: </span><span class="details-value">${Percentage}</span></div>
     <div><span class="details-title">Population: </span><span class="details-value">${Population}</span></div>
@@ -231,6 +232,8 @@ const setUpParkingLotsLayer = (map) => {
 };
 
 const setUpSite = () => {
+  setUpIcons();
+
   const initialCityId = extractCityIdFromUrl(window.location.href);
   addCitiesToToggle(initialCityId, "columbus-oh");
   setUpAbout();

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -160,7 +160,7 @@ const generateScorecard = (cityProperties) => {
   } = cityProperties;
   let result = `
     <div class="title">${Name}</div>
-    <div class="url-copy-button"><a href="#"><i class="fa-solid fa-link fa-lg" style="color: #21ccb9;"></i></a></div>
+    <div class="url-copy-button"><a href="#"><i class="fa-solid fa-link fa-lg"></i></a></div>
     <hr>
     <div><span class="details-title">Percent of Central City Devoted to Parking: </span><span class="details-value">${Percentage}</span></div>
     <div><span class="details-title">Population: </span><span class="details-value">${Population}</span></div>

--- a/src/js/vendor/leaflet.zoomhome.js
+++ b/src/js/vendor/leaflet.zoomhome.js
@@ -47,7 +47,7 @@ class ZoomHome extends Control.Zoom {
       container,
       this._zoomIn.bind(this)
     );
-    const zoomHomeText = `<i class="fa fa-${options.zoomHomeIcon}" style="line-height:1.65;"></i>`;
+    const zoomHomeText = `<i class="fa-solid fa-${options.zoomHomeIcon}" style="line-height:1.65;"></i>`;
     this._zoomHomeButton = this._createButton(
       zoomHomeText,
       options.zoomHomeTitle,


### PR DESCRIPTION
Closes https://github.com/ParkingReformNetwork/parking-lot-map/issues/51.

This uses Parcel's "tree shaking" to only bundle the icons we actually use.

This also results in Font Awesome now using SVGs, which are better and scale perfectly regardless of screen size.

## Before

<img width="83" alt="Captura de pantalla 2023-04-08 a la(s) 9 32 04 a m" src="https://user-images.githubusercontent.com/14852634/230729798-3dcd6f72-966c-452c-b94a-49f915bdcdd3.png">

<img width="34" alt="Captura de pantalla 2023-04-08 a la(s) 9 32 37 a m" src="https://user-images.githubusercontent.com/14852634/230729808-adbbe145-7547-4bf9-a7da-df9286a860b1.png">

<img width="57" alt="Captura de pantalla 2023-04-08 a la(s) 9 32 59 a m" src="https://user-images.githubusercontent.com/14852634/230729838-638234c9-cbd6-4175-b033-0a6182578514.png">

## After

<img width="82" alt="Captura de pantalla 2023-04-08 a la(s) 9 30 32 a m" src="https://user-images.githubusercontent.com/14852634/230729734-4c91489f-b538-49f8-b7d9-c9711cf2530d.png">

<img width="36" alt="Captura de pantalla 2023-04-08 a la(s) 9 38 55 a m" src="https://user-images.githubusercontent.com/14852634/230730106-81ef8164-ea98-4db8-b548-9a4958e3994d.png">


<img width="71" alt="Captura de pantalla 2023-04-08 a la(s) 9 31 51 a m" src="https://user-images.githubusercontent.com/14852634/230729783-a7311927-40cb-491d-82d3-03a5f5d959be.png">
