### PR TITLE
Switch home icon for globe icon

### DIFF
--- a/src/js/fontAwesome.js
+++ b/src/js/fontAwesome.js
@@ -1,15 +1,21 @@
 import { library, dom } from "@fortawesome/fontawesome-svg-core";
 import {
-  faHome,
-  faLink,
   faCircleInfo,
   faCircleXmark,
+  faEarthAmericas,
+  faLink,
   faUpRightFromSquare,
 } from "@fortawesome/free-solid-svg-icons";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 
 const setUpIcons = () => {
-  library.add(faCircleInfo, faCircleXmark, faHome, faLink, faUpRightFromSquare);
+  library.add(
+    faCircleInfo,
+    faCircleXmark,
+    faEarthAmericas,
+    faLink,
+    faUpRightFromSquare
+  );
   dom.watch();
 };
 

--- a/src/js/vendor/leaflet.zoomhome.js
+++ b/src/js/vendor/leaflet.zoomhome.js
@@ -20,7 +20,7 @@ class ZoomHome extends Control.Zoom {
       zoomInTitle: "Zoom in",
       zoomOutText: "-",
       zoomOutTitle: "Zoom out",
-      zoomHomeIcon: "home",
+      zoomHomeIcon: "earth-americas",
       zoomHomeTitle: "Home",
       homeCoordinates: null,
       homeZoom: null,


### PR DESCRIPTION
This is much more intuitive than a home icon, which wasn't clear what it was.

We went with the globe rather than a US flag because we want to expand to Canada and Mexico.

<img width="33" alt="Captura de pantalla 2023-04-08 a la(s) 9 49 40 a m" src="https://user-images.githubusercontent.com/14852634/230730579-60421476-7081-420c-b713-25522aac87ba.png">
