### PR TITLE
Workaround scope hoisting bug in Parcel

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,7 +1,6 @@
 {
   "extends": "@parcel/config-default",
   "transformers": {
-    "*.geojson": ["@parcel/transformer-json"],
-    "*.js": ["@parcel/transformer-js"]
+    "*.geojson": ["@parcel/transformer-json"]
   }
 }


### PR DESCRIPTION
See https://github.com/parcel-bundler/parcel/issues/8938. This has been breaking the staging deploy since https://github.com/ParkingReformNetwork/parking-lot-map/pull/78.

Turns out we didn't need this config. It was only to silence Parcel complaining about Babel. We probably don't need it now because we don't have a `.babelrc` file like when I first tried adding Babel. 