### PR TITLE
Enable compression

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,5 +1,12 @@
 {
   "extends": "@parcel/config-default",
+  "compressors": {
+    "*.{html,css,js,svg,map}": [
+      "...",
+      "@parcel/compressor-gzip",
+      "@parcel/compressor-brotli"
+    ]
+  },
   "transformers": {
     "*.geojson": ["@parcel/transformer-json"]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@babel/core": "^7.21.4",
         "@babel/preset-env": "^7.21.4",
         "@jest/globals": "^29.5.0",
+        "@parcel/compressor-brotli": "^2.8.3",
+        "@parcel/compressor-gzip": "^2.8.3",
         "babel-jest": "^29.5.0",
         "eslint": "^8.37.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -2701,6 +2703,40 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/compressor-brotli": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-brotli/-/compressor-brotli-2.8.3.tgz",
+      "integrity": "sha512-RavknrtGFagtlTdD5Km94bot6MViFRW/IUFH/bUHCTgl5WB1hD5qJaS8xbO0HJt1/jvuWzrGu5lqfo3MR+QFKQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/compressor-gzip": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-gzip/-/compressor-gzip-2.8.3.tgz",
+      "integrity": "sha512-WLYP0vDD4oTPjKBKgTdALAb2wWCYjRvs8cw5fHze4905BlO5Oqye+YnAk2Mvdj5ng2iucleQB/+IBxy7oYo+yQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@babel/core": "^7.21.4",
     "@babel/preset-env": "^7.21.4",
     "@jest/globals": "^29.5.0",
+    "@parcel/compressor-brotli": "^2.8.3",
+    "@parcel/compressor-gzip": "^2.8.3",
     "babel-jest": "^29.5.0",
     "eslint": "^8.37.0",
     "eslint-config-airbnb-base": "^15.0.0",


### PR DESCRIPTION
First part of https://github.com/ParkingReformNetwork/parking-lot-map/issues/58.

We then need to make sure the server is configured to use the compressed files.

We build the original uncompressed, gzip compressed, and brotli compressed. The server will determine which version to send based on the client.

`npm run build` now results in this:

```
124k index.17342985.css
 17k index.17342985.css.br
 21k index.17342985.css.gz
342k index.17342985.css.map
 32k index.17342985.css.map.br
 49k index.17342985.css.map.gz
4.0k index.cb0a4f29.css
 932 index.cb0a4f29.css.br
1.2k index.cb0a4f29.css.gz
 12k index.cb0a4f29.css.map
1.8k index.cb0a4f29.css.map.br
2.1k index.cb0a4f29.css.map.gz
 216 index.e87b1b9a.css
 137 index.e87b1b9a.css.br
 170 index.e87b1b9a.css.gz
 633 index.e87b1b9a.css.map
 274 index.e87b1b9a.css.map.br
 292 index.e87b1b9a.css.map.gz
2.3M index.html
374k index.html.br
528k index.html.gz
1.3k layers-2x.b7b89169.png
 696 layers.760a0456.png
1.5k marker-icon.3f7d3721.png
7.6k parking-reform-network.deea73d9.png
```

The compressed version of index.html is 15% the normal size 🙌