### PR TITLE
Use the same font as main site

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,12 @@
 <html>
   <head>
     <title>Parking Lot Map - Parking Reform Network</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Explore how much land cities dedicate to parking in over 50 cities included on the map below. Click the drop-down icon in the upper right corner to select a&#8230;"
+    />
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
       async
@@ -17,12 +23,6 @@
       gtag("config", "G-5MFS4ZVMY3");
     </script>
 
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      name="description"
-      content="Explore how much land cities dedicate to parking in over 50 cities included on the map below. Click the drop-down icon in the upper right corner to select a&#8230;"
-    />
     <meta
       property="og:image"
       content="https://parkingreform.org/wp-content/uploads/2023/03/lotmapbanner.png"

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,5 +1,6 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");
+
 body {
-  font-family: Helvetica, Arial, sans-serif;
   padding: 0;
   margin: 0;
 }
@@ -8,6 +9,11 @@ body,
 #map {
   height: 100%;
   width: 100%;
+}
+
+body,
+.leaflet-container {
+  font-family: Poppins, Helvetica, Arial, sans-serif;
 }
 
 dd {
@@ -22,9 +28,9 @@ fieldset#tier-dropdown {
 }
 #city-choice {
   font-size: 20px;
-  padding: 5px;
+  padding: 3px 5px;
   border: 2px solid rgba(0, 0, 0, 0.2);
-  border-radius: 5px;
+  border-radius: 10px;
 }
 
 .leaflet-touch .leaflet-control-layers-toggle {


### PR DESCRIPTION
## Before

<img width="175" alt="Captura de pantalla 2023-04-08 a la(s) 2 37 47 p m" src="https://user-images.githubusercontent.com/14852634/230741633-6ba995c5-f67c-40c8-bbe4-2fefaf5b1c2b.png">

<img width="428" alt="Captura de pantalla 2023-04-08 a la(s) 2 39 04 p m" src="https://user-images.githubusercontent.com/14852634/230741677-71f7b305-a359-459d-99f1-c11f7522826b.png">

<img width="907" alt="Captura de pantalla 2023-04-08 a la(s) 2 39 23 p m" src="https://user-images.githubusercontent.com/14852634/230741685-615cb180-836f-42dc-8c8d-25471e7a5bc2.png">

## After

<img width="187" alt="Captura de pantalla 2023-04-08 a la(s) 2 38 32 p m" src="https://user-images.githubusercontent.com/14852634/230741659-8b4b6258-4222-4b12-8433-5d0b95b1bfb1.png">

<img width="442" alt="Captura de pantalla 2023-04-08 a la(s) 2 38 50 p m" src="https://user-images.githubusercontent.com/14852634/230741670-38bb724e-96ab-467c-83c9-04981c1b4d70.png">

<img width="923" alt="Captura de pantalla 2023-04-08 a la(s) 2 39 36 p m" src="https://user-images.githubusercontent.com/14852634/230741691-538b427b-794b-44e3-bd6f-58b6b8471d29.png">

## Google Fonts

I tried using this from our main site:

<link rel="preload" href="https://parkingreform.org/wp-content/astra-local-fonts/poppins/pxiByp8kv8JHgFVrLCz7Z1xlFQ.woff2" as="font" type="font/woff2" crossorigin="">

But it failed to load when developing because of CORS (cross origin resource policy), which doesn't let us use the font other than on parkingreform.org