### PR TITLE
Lazy load parking data

### DIFF
--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -6,7 +6,6 @@ import { determineShareUrl, extractCityIdFromUrl } from "./cityId";
 import setUpIcons from "./fontAwesome";
 import ZoomHome from "./vendor/leaflet.zoomhome";
 import citiesData from "../../data/cities-polygons.geojson";
-import parkingLotsData from "../../data/parking-lots.geojson";
 
 const BASE_LAYERS = {
   Light: new TileLayer(
@@ -224,11 +223,13 @@ const setUpCitiesLayer = (map) => {
 };
 
 const setUpParkingLotsLayer = (map) => {
-  geoJSON(parkingLotsData, {
-    style() {
-      return STYLES.parkingLots;
-    },
-  }).addTo(map);
+  import("../../data/parking-lots.geojson").then((parkingLotsData) => {
+    geoJSON(parkingLotsData, {
+      style() {
+        return STYLES.parkingLots;
+      },
+    }).addTo(map);
+  });
 };
 
 const setUpSite = () => {


### PR DESCRIPTION
This results in Parcel using code splitting: https://parceljs.org/features/code-splitting/. The parking lots GeoJSON data has its own JavaScript file.

That allows us to have a faster initial page load, such as setting up the city toggle and city boundaries. We still load the city data eagerly because it's essential to the page rendering, unlike the parking lots.