### PR TITLE
`#no-lots` in URL hides parking lots

### DIFF
--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -44,6 +44,12 @@ const STYLES = {
   },
 };
 
+// Temporary hack to allow removing the parking lot data.
+if (window.location.href.indexOf("#no-lots") !== -1) {
+  STYLES.parkingLots.weight = 0;
+  STYLES.parkingLots.fillOpacity = 0;
+}
+
 const addCitiesToToggle = (initialCityId, fallbackCityId) => {
   const cityToggleElement = document.getElementById("city-choice");
   let validInitialId = false;


### PR DESCRIPTION
Request from Tony for an upcoming presentation. We can remove this when no longer relevant.