### PR TITLE
Revert "`#no-lots` in URL hides parking lots (#92)"

### DIFF
--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -44,12 +44,6 @@ const STYLES = {
   },
 };
 
-// Temporary hack to allow removing the parking lot data.
-if (window.location.href.indexOf("#no-lots") !== -1) {
-  STYLES.parkingLots.weight = 0;
-  STYLES.parkingLots.fillOpacity = 0;
-}
-
 const addCitiesToToggle = (initialCityId, fallbackCityId) => {
   const cityToggleElement = document.getElementById("city-choice");
   let validInitialId = false;


### PR DESCRIPTION
The approach didn't work. We need to use something like https://github.com/ParkingReformNetwork/parking-lot-map/pull/93. 