### PR TITLE
Hide parking lots toggle unless #lots-toggle in URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,8 +100,10 @@
           ></i>
         </div>
         <h2>Parking Lot Coverage Map</h2>
-        <h3 id="lot-data-on"><a>Click me turn on lot data.</a></h3>
-        <h3 id="lot-data-off"><a>Click me turn off lot data.</a></h3>
+        <div id="lots-toggle" style="display: none">
+          <h3 id="lots-toggle-on"><a>Click me turn on lot data.</a></h3>
+          <h3 id="lots-toggle-off"><a>Click me turn off lot data.</a></h3>
+        </div>
         <ul>
           <li>
             <a href="https://parkingreform.org/resources/parking-lot-map/"

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -234,13 +234,16 @@ const setUpParkingLotsLayer = async (map) => {
     },
   }).addTo(map);
 
-  // Hack to allow turning off lot data.
-  document.querySelector("#lot-data-on").addEventListener("click", () => {
-    lotsLayer.addData(parkingLotsData);
-  });
-  document.querySelector("#lot-data-off").addEventListener("click", () => {
-    lotsLayer.clearLayers();
-  });
+  // If `#lots-toggle` is in the URL, we show buttons to toggle parking lots.
+  if (window.location.href.indexOf("#lots-toggle") !== -1) {
+    document.querySelector("#lots-toggle").style.display = "block";
+    document.querySelector("#lots-toggle-on").addEventListener("click", () => {
+      lotsLayer.addData(parkingLotsData);
+    });
+    document.querySelector("#lots-toggle-off").addEventListener("click", () => {
+      lotsLayer.clearLayers();
+    });
+  }
 };
 
 const setUpSite = async () => {


### PR DESCRIPTION
This allows us to push this lots toggle functionality to production. Tony thinks it may be useful in the future.