### PR TITLE
Use modern `navigator.clipboard` API

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "playwright test",
     "fmt": "prettier --write .",
     "fix": "prettier --write scripts/ src/ tests/; eslint --fix scripts/ src/ tests/",
-    "lint": "prettier --check . && eslint scripts/ src/",
+    "lint": "prettier --check . && eslint scripts/ src/ tests/",
     "add-city": "node scripts/add-city.js",
     "update-city-boundaries": "node scripts/update-city-boundaries.js",
     "update-lots": "node scripts/update-lots.js",

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -1,4 +1,4 @@
-/* global document, window */
+/* global document, navigator, window */
 import { Control, Map, Popup, TileLayer, geoJSON } from "leaflet";
 import "leaflet/dist/leaflet.css";
 
@@ -107,13 +107,13 @@ const createMap = () => {
  *
  * @param string value
  */
-const copyToClipboard = (value) => {
-  const dummy = document.createElement("textarea");
-  document.body.appendChild(dummy);
-  dummy.value = value;
-  dummy.select();
-  document.execCommand("copy");
-  document.body.removeChild(dummy);
+const copyToClipboard = async (value) => {
+  try {
+    await navigator.clipboard.writeText(value);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("Failed to write to clipboard: ", err);
+  }
 
   const copiedLinkMessageElement = document.querySelector(
     ".copied-link-message"
@@ -132,11 +132,11 @@ const copyToClipboard = (value) => {
 const setUpShareUrlClickListener = (cityId) => {
   // We put the event listener on `map` because it is never erased, unlike the copy button
   // being recreated every time the score card changes. This is called "event delegation".
-  document.querySelector("#map").addEventListener("click", (event) => {
+  document.querySelector("#map").addEventListener("click", async (event) => {
     const targetElement = event.target.closest("div.url-copy-button > a");
     if (targetElement) {
       const shareUrl = determineShareUrl(window.location.href, cityId);
-      copyToClipboard(shareUrl);
+      await copyToClipboard(shareUrl);
     }
   });
 };

--- a/tests/app/setUpSite.test.js
+++ b/tests/app/setUpSite.test.js
@@ -86,7 +86,7 @@ test("correctly load the city score card", async ({ page }) => {
 test.describe("the share feature", () => {
   test("share button writes the URL to the clipboard", async ({ browser }) => {
     const context = await browser.newContext();
-    await context.grantPermissions(["clipboard-read"]);
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     const page = await context.newPage();
     await page.goto("");
 


### PR DESCRIPTION
This is a safer and more modern way to write to the clipboard.

We couldn't do it before because I couldn't get things to work with Puppeteer. Playwright Just Works.