### PR TITLE
Add city type to score card

### DIFF
--- a/data/score-cards.json
+++ b/data/score-cards.json
@@ -2,171 +2,191 @@
   "albuquerque-nm": {
     "Name": "Albuquerque, NM",
     "Percentage": "33%",
+    "cityType": "core city",
     "Population": "564,559",
     "Metro Population": "916,528",
     "Parking Score": "N/A",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "anaheim-ca": {
     "Name": "Anaheim, CA",
     "Percentage": "23%",
+    "cityType": "node city",
     "Population": "346,824",
     "Metro Population": "3,186,989",
     "Parking Score": "61",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "anchorage-ak": {
     "Name": "Anchorage, AK",
     "Percentage": "30%",
+    "cityType": "core city",
     "Population": "291,247",
     "Metro Population": "398,328",
     "Parking Score": "N/A",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Anchorage_AK.html"
   },
   "arlington-tx": {
     "Name": "Arlington, TX",
     "Percentage": "42%",
+    "cityType": "satellite city",
     "Population": "394,218",
     "Metro Population": "7,637,387",
     "Parking Score": "90",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "atlanta-ga": {
     "Name": "Atlanta, GA",
     "Percentage": "25%",
+    "cityType": "core city",
     "Population": "498,715",
     "Metro Population": "6,089,815",
     "Parking Score": "79",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Atlanta_GA.html"
   },
   "aurora-co": {
     "Name": "Aurora, CO",
     "Percentage": "26%",
+    "cityType": "satellite city",
     "Population": "386,261",
     "Metro Population": "2,963,821",
     "Parking Score": "43",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "austin-tx": {
     "Name": "Austin, TX",
     "Percentage": "17%",
+    "cityType": "core city",
     "Population": "402,907",
     "Metro Population": "2,283,371",
     "Parking Score": "42",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Austin_TX.html"
   },
   "bakersfield-ca": {
     "Name": "Bakersfield, CA",
     "Percentage": "26%",
+    "cityType": "core city",
     "Population": "403,455",
     "Metro Population": "909,235",
     "Parking Score": "N/A",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "baltimore-md": {
     "Name": "Baltimore, MD",
     "Percentage": "11%",
+    "cityType": "core city",
     "Population": "585,708",
     "Metro Population": "2,844,510",
     "Parking Score": "29",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Baltimore_MD.html"
   },
   "birmingham-al": {
     "Name": "Birmingham, AL",
     "Percentage": "26%",
+    "cityType": "core city",
     "Population": "200,733",
     "Metro Population": "1,115,289",
     "Parking Score": "55",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Birmingham_AL.html"
   },
   "boston-ma": {
     "Name": "Boston, MA",
     "Percentage": "6%",
+    "cityType": "core city",
     "Population": "676,216",
     "Metro Population": "4,941,632",
     "Parking Score": "17",
-    "Reforms": "Passed",
+    "Reforms": "passed",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Boston_MA.html"
   },
   "buffalo-ny": {
     "Name": "Buffalo, NY",
     "Percentage": "29%",
+    "cityType": "core city",
     "Population": "278,349",
     "Metro Population": "1,166,902",
     "Parking Score": "62",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Buffalo_NY.html"
   },
   "charlotte-nc": {
     "Name": "Charlotte, NC",
     "Percentage": "18%",
+    "cityType": "core city",
     "Population": "874,541",
     "Metro Population": "2,660,329",
     "Parking Score": "46",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Charlotte_NC.html"
   },
   "chicago-il": {
     "Name": "Chicago, IL",
     "Percentage": "4%",
+    "cityType": "core city",
     "Population": "2,747,231",
     "Metro Population": "9,618,502",
     "Parking Score": "14",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Chicago_IL.html"
   },
   "cincinnati-oh": {
     "Name": "Cincinnati, OH",
     "Percentage": "21%",
+    "cityType": "core city",
     "Population": "309,317",
     "Metro Population": "2,256,884",
     "Parking Score": "48",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Cincinnati_OH.html"
   },
   "cleveland-oh": {
     "Name": "Cleveland, OH",
     "Percentage": "26%",
+    "cityType": "core city",
     "Population": "373,091",
     "Metro Population": "2,088,251",
     "Parking Score": "66",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Cleveland_OH.html"
   },
   "colorado-springs-co": {
     "Name": "Colorado Springs, CO",
     "Percentage": "21%",
+    "cityType": "core city",
     "Population": "478,961",
     "Metro Population": "755,105",
     "Parking Score": "N/A",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/ColoradoSprings_CO.html"
   },
   "columbus-oh": {
     "Name": "Columbus, OH",
     "Percentage": "27%",
+    "cityType": "core city",
     "Population": "905,672",
     "Metro Population": "2,138,926",
     "Parking Score": "68",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Columbus_OH.html"
   },
   "corpus-christi-tx": {
     "Name": "Corpus Christi, TX",
     "Percentage": "33%",
+    "cityType": "core city",
     "Population": "317,863",
     "Metro Population": "421,933",
     "Parking Score": "N/A",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "dallas-tx": {
     "Name": "Dallas, TX",
     "Percentage": "24%",
+    "cityType": "twin city",
     "Population": "1,304,442",
     "Metro Population": "7,637,387",
     "Parking Score": "74",
@@ -176,213 +196,238 @@
   "denver-co": {
     "Name": "Denver, CO",
     "Percentage": "11%",
+    "cityType": "core city",
     "Population": "715,522",
     "Metro Population": "2,963,821",
     "Parking Score": "28",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "detroit-mi": {
     "Name": "Detroit, MI",
     "Percentage": "30%",
+    "cityType": "core city",
     "Population": "639,614",
     "Metro Population": "4,392,041",
     "Parking Score": "86",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Detroit_MI.html"
   },
   "el-paso-tx": {
     "Name": "El Paso, TX",
     "Percentage": "23%",
+    "cityType": "twin city",
     "Population": "678,815",
     "Metro Population": "868,859",
     "Parking Score": "N/A",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/ElPaso_TX.html"
   },
   "fort-worth-tx": {
     "Name": "Fort Worth, TX",
     "Percentage": "27%",
+    "cityType": "twin city",
     "Population": "918,377",
     "Metro Population": "7,637,387",
     "Parking Score": "85",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/FortWorth_TX.html"
   },
   "fresno-ca": {
     "Name": "Fresno, CA",
     "Percentage": "30%",
+    "cityType": "core city",
     "Population": "542,107",
     "Metro Population": "1,008,654",
     "Parking Score": "65",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Fresno_CA.html"
   },
   "grand-rapids-mi": {
     "Name": "Grand Rapids, MI",
     "Percentage": "28%",
+    "cityType": "core city",
     "Population": "198,917",
     "Metro Population": "1,087,592",
     "Parking Score": "58",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/GrandRapids_MI.html"
   },
   "greensboro-nc": {
     "Name": "Greensboro, NC",
     "Percentage": "32%",
+    "cityType": "core city",
     "Population": "299,035",
     "Metro Population": "776,566",
     "Parking Score": "N/A",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "hartford-ct": {
     "Name": "Hartford, CT",
     "Percentage": "22%",
+    "cityType": "core city",
     "Population": "121,054",
     "Metro Population": "1,150,509",
     "Parking Score": "41",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Hartford_CT.html"
   },
   "henderson-nv": {
     "Name": "Henderson, NV",
     "Percentage": "28%",
+    "cityType": "satellite city",
     "Population": "317,610",
     "Metro Population": "2,265,461",
     "Parking Score": "46",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "honolulu-hi": {
     "Name": "Honolulu, HI",
     "Percentage": "15%",
+    "cityType": "core city",
     "Population": "350,964",
     "Metro Population": "1,016,508",
     "Parking Score": "20",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Honolulu_HI.html"
   },
   "houston-tx": {
     "Name": "Houston, TX",
     "Percentage": "26%",
+    "cityType": "core city",
     "Population": "2,302,792",
     "Metro Population": "7,122,240",
     "Parking Score": "80",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Houston_TX.html"
   },
   "indianapolis-in": {
     "Name": "Indianapolis, IN",
     "Percentage": "24%",
+    "cityType": "core city",
     "Population": "887,752",
     "Metro Population": "2,111,040",
     "Parking Score": "61",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Indianapolis_IN.html"
   },
   "jacksonville-fl": {
     "Name": "Jacksonville, FL",
     "Percentage": "29%",
+    "cityType": "core city",
     "Population": "887,752",
     "Metro Population": "2,111,040",
     "Parking Score": "61",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Jacksonville_FL.html"
   },
   "jersey-city-nj": {
     "Name": "Jersey City, NJ",
     "Percentage": "20%",
+    "cityType": "satellite city",
     "Population": "292,449",
     "Metro Population": "20,140,470",
     "Parking Score": "34",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/JerseyCity_NJ.html"
   },
   "kansas-city-mo": {
     "Name": "Kansas City, MO",
     "Percentage": "29%",
+    "cityType": "core city",
     "Population": "507,969",
     "Metro Population": "2,192,035",
     "Parking Score": "76",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/KansasCity_MO.html"
   },
   "las-vegas-nv": {
     "Name": "Las Vegas, NV",
     "Percentage": "32%",
+    "cityType": "core city",
     "Population": "641,825",
     "Metro Population": "2,265,461",
     "Parking Score": "83",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "lexington-ky": {
     "Name": "Lexington, KY",
     "Percentage": "38%",
+    "cityType": "core city",
     "Population": "322,570",
     "Metro Population": "516,811",
     "Parking Score": "N/A",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Lexington_KY.html"
   },
   "lincoln-ne": {
     "Name": "Lincoln, NE",
     "Percentage": "23%",
+    "cityType": "core city",
     "Population": "291,082",
     "Metro Population": "340,217",
     "Parking Score": "N/A",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "long-beach-ca": {
     "Name": "Long Beach, CA",
     "Percentage": "18%",
+    "cityType": "satellite city",
     "Population": "466,302",
     "Metro Population": "13,200,998",
     "Parking Score": "18",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "los-angeles-ca": {
     "Name": "Los Angeles, CA",
     "Percentage": "12%",
+    "cityType": "core city",
     "Population": "3,893,986",
     "Metro Population": "13,200,998",
     "Parking Score": "41",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/LosAngeles_CA.html"
   },
   "louisville-ky": {
     "Name": "Louisville, KY",
     "Percentage": "28%",
+    "cityType": "core city",
     "Population": "632,689",
     "Metro Population": "1,395,634",
     "Parking Score": "59",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Louisville_KY.html"
   },
   "lubbock-tx": {
     "Name": "Lubbock, TX",
     "Percentage": "35%",
+    "cityType": "",
     "Population": "257,141",
     "Metro Population": "321,368",
     "Parking Score": "89",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "memphis-tn": {
     "Name": "Memphis, TN",
     "Percentage": "25%",
+    "cityType": "core city",
     "Population": "633,104",
     "Metro Population": "1,337,779",
     "Parking Score": "48",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "mesa-az": {
     "Name": "Mesa, AZ",
     "Percentage": "32%",
+    "cityType": "satellite city",
     "Population": "504,500",
     "Metro Population": "4,845,832",
     "Parking Score": "58",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "miami-fl": {
     "Name": "Miami, FL",
     "Percentage": "18%",
+    "cityType": "core city",
     "Population": "442,265",
     "Metro Population": "6,138,333",
     "Parking Score": "57",
@@ -392,366 +437,408 @@
   "milwaukee-wi": {
     "Name": "Milwaukee, WI",
     "Percentage": "18%",
+    "cityType": "core city",
     "Population": "577,222",
     "Metro Population": "1,574,731",
     "Parking Score": "28",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Milwaukee_WI.html"
   },
   "minneapolis-mn": {
     "Name": "Minneapolis, MN",
     "Percentage": "17%",
+    "cityType": "twin city",
     "Population": "428,403",
     "Metro Population": "3,690,261",
     "Parking Score": "42",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Minneapolis_MN.html"
   },
   "nashville-tn": {
     "Name": "Nashville, TN",
     "Percentage": "19%",
+    "cityType": "core city",
     "Population": "689,504",
     "Metro Population": "1,989,519",
     "Parking Score": "47",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Nashville_TN.html"
   },
   "new-haven-ct": {
     "Name": "New Haven, CT",
     "Percentage": "19%",
+    "cityType": "core city",
     "Population": "134,023",
     "Metro Population": "1,020,915",
     "Parking Score": "30",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "new-orleans-la": {
     "Name": "New Orleans, LA",
     "Percentage": "19%",
+    "cityType": "core city",
     "Population": "383,997",
     "Metro Population": "1,271,845",
     "Parking Score": "30",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/NewOrleans_LA.html"
   },
   "new-york-ny": {
     "Name": "New York, NY",
     "Percentage": "1%",
+    "cityType": "core city",
     "Population": "8,804,190",
     "Metro Population": "20,140,470",
     "Parking Score": "5",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/NewYorkCIty_NY.html"
   },
   "newark-nj": {
     "Name": "Newark, NJ",
     "Percentage": "24%",
+    "cityType": "satellite city",
     "Population": "311,549",
     "Metro Population": "20,140,470",
     "Parking Score": "41",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Newark_NJ.html"
   },
   "norfolk-va": {
     "Name": "Norfolk, VA",
     "Percentage": "23%",
+    "cityType": "core city",
     "Population": "238,005",
     "Metro Population": "1,799,675",
     "Parking Score": "43",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Norfolk_VA.html"
   },
   "oakland-ca": {
     "Name": "Oakland, CA",
     "Percentage": "12%",
+    "cityType": "twin city",
     "Population": "439,349",
     "Metro Population": "4,749,008",
     "Parking Score": "33",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Oakland_CA.html"
   },
   "oklahoma-city-ok": {
     "Name": "Oklahoma City, OK",
     "Percentage": "28%",
+    "cityType": "core city",
     "Population": "681,054",
     "Metro Population": "1,425,695",
     "Parking Score": "59",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/OklahomaCity_OK.html"
   },
   "omaha-ne": {
     "Name": "Omaha, NE",
     "Percentage": "21%",
+    "cityType": "core city",
     "Population": "486,051",
     "Metro Population": "967,604",
     "Parking Score": "36",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Omaha_NE.html"
   },
   "orlando-fl": {
     "Name": "Orlando, FL",
     "Percentage": "29%",
+    "cityType": "core city",
     "Population": "307,573",
     "Metro Population": "2,673,376",
     "Parking Score": "76",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "philadelphia-pa": {
     "Name": "Philadelphia, PA",
     "Percentage": "13%",
+    "cityType": "core city",
     "Population": "1,603,797",
     "Metro Population": "6,245,051",
     "Parking Score": "40",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Philadelphia_PA.html"
   },
   "phoenix-az": {
     "Name": "Phoenix, AZ",
     "Percentage": "21%",
+    "cityType": "core city",
     "Population": "1,607,739",
     "Metro Population": "4,845,832",
     "Parking Score": "59",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Phoenix_AZ.html"
   },
   "pittsburgh-pa": {
     "Name": "Pittsburgh, PA",
     "Percentage": "15%",
+    "cityType": "core city",
     "Population": "302,971",
     "Metro Population": "2,370,930",
     "Parking Score": "33",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "portland-or": {
     "Name": "Portland, OR",
     "Percentage": "11%",
+    "cityType": "core city",
     "Population": "652,089",
     "Metro Population": "2,512,859",
     "Parking Score": "22",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Portland_OR.html"
   },
   "providence-ri": {
     "Name": "Providence, RI",
     "Percentage": "24%",
+    "cityType": "core city",
     "Population": "190,934",
     "Metro Population": "1,676,579",
     "Parking Score": "46",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Providence_RI.html"
   },
   "raleigh-nc": {
     "Name": "Raleigh, NC",
     "Percentage": "28%",
+    "cityType": "core city",
     "Population": "467,665",
     "Metro Population": "1,413,982",
     "Parking Score": "58",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Raleigh_NC.html"
   },
   "riverside-ca": {
     "Name": "Riverside, CA",
     "Percentage": "34%",
+    "cityType": "node city",
     "Population": "317,610",
     "Metro Population": "4,599,839",
     "Parking Score": "99",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "rochester-ny": {
     "Name": "Rochester, NY",
     "Percentage": "28%",
+    "cityType": "core city",
     "Population": "211,328",
     "Metro Population": "1,090,135",
     "Parking Score": "59",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Rochester_NY.html"
   },
   "sacramento-ca": {
     "Name": "Sacramento, CA",
     "Percentage": "17%",
+    "cityType": "core city",
     "Population": "522,754",
     "Metro Population": "2,397,382",
     "Parking Score": "38",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Sacramento_CA.html"
   },
   "saint-louis-mo": {
     "Name": "Saint Louis, MO",
     "Percentage": "21%",
+    "cityType": "core city",
     "Population": "301,578",
     "Metro Population": "2,820,253",
     "Parking Score": "51",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/St.Louis_MO.html"
   },
   "saint-paul-mn": {
     "Name": "Saint Paul, MN",
     "Percentage": "16%",
+    "cityType": "twin city",
     "Population": "311,527",
     "Metro Population": "3,690,261",
     "Parking Score": "38",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/St.Paul_MN.html"
   },
   "salt-lake-city-ut": {
     "Name": "Salt Lake City, UT",
     "Percentage": "29%",
+    "cityType": "core city",
     "Population": "199,723",
     "Metro Population": "1,257,936",
     "Parking Score": "61",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/SaltLakeCity_UT.html"
   },
   "san-antonio-tx": {
     "Name": "San Antonio, TX",
     "Percentage": "28%",
+    "cityType": "core city",
     "Population": "1,434,270",
     "Metro Population": "2,558,143",
     "Parking Score": "72",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/SanAntonio_TX.html"
   },
   "san-bernardino-ca": {
     "Name": "San Bernardino, CA",
     "Percentage": "49%",
+    "cityType": "node city",
     "Population": "221,101",
     "Metro Population": "4,599,839",
     "Parking Score": "100",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "san-diego-ca": {
     "Name": "San Diego, CA",
     "Percentage": "14%",
+    "cityType": "core city",
     "Population": "1,385,922",
     "Metro Population": "3,298,634",
     "Parking Score": "32",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/SanDiego_CA.html"
   },
   "san-francisco-ca": {
     "Name": "San Francisco, CA",
     "Percentage": "4%",
+    "cityType": "twin city",
     "Population": "873,965",
     "Metro Population": "4,749,008",
     "Parking Score": "8",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/SanFrancisco_CA.html"
   },
   "san-jose-ca": {
     "Name": "San Jose, CA",
     "Percentage": "14%",
+    "cityType": "core city",
     "Population": "1,014,545",
     "Metro Population": "2,000,468",
     "Parking Score": "31",
-    "Reforms": "Passed",
+    "Reforms": "passed",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/SanJose_CA.html"
   },
   "san-juan-pr": {
     "Name": "San Juan, PR",
     "Percentage": "7%",
+    "cityType": "core city",
     "Population": "342,259",
     "Metro Population": "2,081,265",
     "Parking Score": "11",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "santa-ana-ca": {
     "Name": "Santa Ana, CA",
     "Percentage": "22%",
+    "cityType": "node city",
     "Population": "310,227",
     "Metro Population": "3,186,989",
     "Parking Score": "57",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "santa-barbara-ca": {
     "Name": "Santa Barbara, CA",
     "Percentage": "27%",
+    "cityType": "",
     "Population": "88,665",
     "Metro Population": "446,475",
     "Parking Score": "N/A",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "seattle-wa": {
     "Name": "Seattle, WA",
     "Percentage": "10%",
+    "cityType": "core city",
     "Population": "735,157",
     "Metro Population": "4,018,762",
     "Parking Score": "27",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Seattle_WA.html"
   },
   "st.-petersburg-fl": {
     "Name": "St. Petersburg, FL",
     "Percentage": "24%",
+    "cityType": "twin city",
     "Population": "258,308",
     "Metro Population": "3,175,275",
     "Parking Score": "63",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/St.Petersburg_FL.html"
   },
   "stockton-ca": {
     "Name": "Stockton, CA",
     "Percentage": "23%",
+    "cityType": "core city",
     "Population": "320,804",
     "Metro Population": "779,233",
     "Parking Score": "N/A",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "tampa-fl": {
     "Name": "Tampa, FL",
     "Percentage": "30%",
+    "cityType": "twin city",
     "Population": "382,769",
     "Metro Population": "3,175,275",
     "Parking Score": "80",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "tucson-az": {
     "Name": "Tucson, AZ",
     "Percentage": "23%",
+    "cityType": "core city",
     "Population": "542,629",
     "Metro Population": "1,043,433",
     "Parking Score": "42",
-    "Reforms": "'No Reforms"
+    "Reforms": "'no reforms"
   },
   "tulsa-ok": {
     "Name": "Tulsa, OK",
     "Percentage": "29%",
+    "cityType": "core city",
     "Population": "413,066",
     "Metro Population": "1,015,331",
     "Parking Score": "61",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Tulsa_OK.html"
   },
   "virginia-beach-va": {
     "Name": "Virginia Beach, VA",
     "Percentage": "35%",
+    "cityType": "satellite city",
     "Population": "459,470",
     "Metro Population": "1,799,674",
     "Parking Score": "69",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   },
   "washington-dc": {
     "Name": "Washington, DC",
     "Percentage": "3%",
+    "cityType": "core city",
     "Population": "689,545",
     "Metro Population": "6,385,162",
     "Parking Score": "12",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/WashingtonDC_DC.html"
   },
   "wichita-ks": {
     "Name": "Wichita, KS",
     "Percentage": "35%",
+    "cityType": "core city",
     "Population": "397,532",
     "Metro Population": "647,610",
     "Parking Score": "N/A",
-    "Reforms": "Implemented",
+    "Reforms": "implemented",
     "Website URL": "https://parkingreform.org/mandates-map/city_detail/Wichita_KS.html"
   },
   "worcester-ma": {
     "Name": "Worcester, MA",
     "Percentage": "35%",
+    "cityType": "core city",
     "Population": "206,518",
     "Metro Population": "978,529",
     "Parking Score": "78",
-    "Reforms": "No Reforms"
+    "Reforms": "no reforms"
   }
 }

--- a/scripts/add-city.js
+++ b/scripts/add-city.js
@@ -6,10 +6,11 @@ const addScoreCard = async (cityId, cityName) => {
   const newEntry = {
     Name: cityName,
     Percentage: "FILL ME IN, e.g. 23%",
+    cityType: "FILL ME IN, e.g. Core City",
     Population: "FILL ME IN, e.g. 346,824",
     "Metro Population": "FILL ME IN, e.g. 13,200,998",
     "Parking Score": "FILL ME IN, e.g. 53",
-    Reforms: "FILL ME IN, either 'No Reforms' or 'Implemented'",
+    Reforms: "FILL ME IN, e.g. No Reforms or Implemented",
     "Website URL": "FILL ME IN OR DELETE ME",
   };
 

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -166,7 +166,7 @@ const generateScorecard = (scoreCardEntry) => {
   if (WebsiteURL) {
     result += `
     <hr>
-    <div class="popup-button"><a href="${WebsiteURL}">View more</a></div>
+    <div class="popup-button"><a href="${WebsiteURL}">View more about reforms</a></div>
   `;
   }
   return result;

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -143,6 +143,7 @@ const setUpShareUrlClickListener = (cityId) => {
 const generateScorecard = (scoreCardEntry) => {
   const {
     Name,
+    cityType,
     Percentage,
     Population,
     "Metro Population": MetroPopulation,
@@ -154,11 +155,13 @@ const generateScorecard = (scoreCardEntry) => {
     <div class="title">${Name}</div>
     <div class="url-copy-button"><a href="#"><i class="fa-solid fa-link fa-xl"></i></a></div>
     <hr>
-    <div><span class="details-title">Percent of Central City Devoted to Parking: </span><span class="details-value">${Percentage}</span></div>
+    <div><span class="details-title">Parking: </span><span class="details-value">${Percentage} of central city</span></div>
+    <div><span class="details-title">Parking score: </span><span class="details-value">${ParkingScore}</span></div>
+    <div><span class="details-title">Parking reform: </span><span class="details-value">${Reforms}</span></div>
+    <br />
+    <div><span class="details-title">City type: </span><span class="details-value">${cityType}</span></div>
     <div><span class="details-title">Population: </span><span class="details-value">${Population}</span></div>
-    <div><span class="details-title">Metro Population: </span><span class="details-value">${MetroPopulation}</span></div>
-    <div><span class="details-title">Parking Score: </span><span class="details-value">${ParkingScore}</span></div>
-    <div><span class="details-title">Parking Mandate Reforms: </span><span class="details-value">${Reforms}</span></div>
+    <div><span class="details-title">Metro population: </span><span class="details-value">${MetroPopulation}</span></div>
   `;
   if (WebsiteURL) {
     result += `

--- a/tests/app/setUpSite.test.js
+++ b/tests/app/setUpSite.test.js
@@ -68,19 +68,17 @@ test("correctly load the city score card", async ({ page }) => {
   });
 
   expect(cityToggleValue).toEqual("anchorage-ak");
-  expect(content["Percent of Central City Devoted to Parking: "]).toEqual(
-    anchorageExpected.Percentage
+  expect(content["Parking: "]).toEqual(
+    `${anchorageExpected.Percentage} of central city`
   );
   expect(content["Population: "]).toEqual(anchorageExpected.Population);
-  expect(content["Metro Population: "]).toEqual(
+  expect(content["Metro population: "]).toEqual(
     anchorageExpected["Metro Population"]
   );
-  expect(content["Parking Score: "]).toEqual(
+  expect(content["Parking score: "]).toEqual(
     anchorageExpected["Parking Score"]
   );
-  expect(content["Parking Mandate Reforms: "]).toEqual(
-    anchorageExpected.Reforms
-  );
+  expect(content["Parking reform: "]).toEqual(anchorageExpected.Reforms);
 });
 
 test.describe("the share feature", () => {


### PR DESCRIPTION
This is important to explain how our methodology works.

This PR also regroups and edits the name of some of the score card entries so that it's more precise. That reduces information overload.

<img width="363" alt="Captura de pantalla 2023-08-10 a la(s) 4 52 08 p m" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/50c40539-cdc2-441b-b504-17efff25a8e3">
