### PR TITLE
Don't close popups when clicking map

### DIFF
--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -85,6 +85,7 @@ const setUpAbout = () => {
 const createMap = () => {
   const map = new Map("map", {
     layers: [BASE_LAYERS.Light],
+    closePopupOnClick: false,
   });
   map.attributionControl.setPrefix(
     'created by <a style="padding: 0 3px 0 3px; color:#fafafa; background-color: #21ccb9;" href=http://www.geocadder.bg/en/>GEOCADDER</a>'


### PR DESCRIPTION
I don't think this was intentional -- it's currently the default behavior. It makes it confusing how to get the popup back.