### PR TITLE
Improve the header to be responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,23 +72,23 @@
 
   <body>
     <header>
-      <div class="site-title">Parking Lot Map</div>
-      <div class="site-controls">
+      <div class="navigation">
+        <span class="site-title">Parking Lot Map</span>
         <fieldset id="city-dropdown">
           <label for="city-choice">Select a city: </label>
           <select name="city-choice" id="city-choice"></select>
         </fieldset>
-        <div class="header-icons">
-          <div class="header-about-icon">
-            <i class="fa-solid fa-circle-info" title="About"></i>
-          </div>
-          <a href="https://parkingreform.org/parking-lot-map/" target="_blank">
-            <i
-              class="fa-solid fa-up-right-from-square"
-              title="View fullscreen"
-            ></i>
-          </a>
+      </div>
+      <div class="header-icons">
+        <div class="header-about-icon">
+          <i class="fa-solid fa-circle-info" title="About"></i>
         </div>
+        <a href="https://parkingreform.org/parking-lot-map/" target="_blank">
+          <i
+            class="fa-solid fa-up-right-from-square"
+            title="View fullscreen"
+          ></i>
+        </a>
       </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -71,26 +71,26 @@
   </head>
 
   <body>
-    <fieldset id="tier-dropdown">
-      <label for="city-choice">Select a city: </label>
-      <select name="city-choice" id="city-choice"></select>
-    </fieldset>
-
-    <div class="banners">
-      <div class="banner-title">Parking Lot Map</div>
-
-      <div class="banner-icons">
-        <div class="banner-about-icon">
-          <i class="fa-solid fa-circle-info" title="About"></i>
+    <header>
+      <div class="site-title">Parking Lot Map</div>
+      <div class="site-controls">
+        <fieldset id="city-dropdown">
+          <label for="city-choice">Select a city: </label>
+          <select name="city-choice" id="city-choice"></select>
+        </fieldset>
+        <div class="header-icons">
+          <div class="header-about-icon">
+            <i class="fa-solid fa-circle-info" title="About"></i>
+          </div>
+          <a href="https://parkingreform.org/parking-lot-map/" target="_blank">
+            <i
+              class="fa-solid fa-up-right-from-square"
+              title="View fullscreen"
+            ></i>
+          </a>
         </div>
-        <a href="https://parkingreform.org/parking-lot-map/" target="_blank">
-          <i
-            class="fa-solid fa-up-right-from-square"
-            title="View fullscreen"
-          ></i>
-        </a>
       </div>
-    </div>
+    </header>
 
     <div class="about-text-popup">
       <div class="about-text-container">

--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -1,28 +1,18 @@
 .leaflet-top.leaflet-left {
-  top: 52px;
+  top: 0.8rem;
 }
 
 .leaflet-touch .leaflet-control-layers-toggle {
-  width: 33px;
-  height: 33px;
+  width: 30px;
+  height: 30px;
 }
 
 #map > div.leaflet-control-container > div.leaflet-top.leaflet-right {
-  top: 130px;
-  margin-left: 9px;
+  top: 8rem;
+  margin-left: 10px;
   right: auto;
 }
 
 .leaflet-control-layers {
   font-size: 12px;
-}
-
-@media only screen and (max-width: 625px) {
-  .leaflet-top.leaflet-left {
-    top: 62px;
-  }
-
-  #map > div.leaflet-control-container > div.leaflet-top.leaflet-right {
-    top: 140px;
-  }
 }

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -1,93 +1,57 @@
-fieldset#tier-dropdown {
-  position: absolute;
-  right: 90px;
-  top: 5px;
-  z-index: 2005;
+header {
+  width: 100%;
+  padding: 0.25em 1em;
+
+  background-color: #4d4d4d;
+  color: white;
+  font-size: 1.4em;
+
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  flex-direction: column;
+
+  @media only screen and (min-width: 48em) {
+    flex-direction: row;
+    font-size: 1.75em;
+  }
+}
+
+.site-title {
+  text-align: center;
+
+  @media only screen and (min-width: 48em) {
+    text-align: left;
+  }
+}
+
+.site-controls {
+  display: flex;
+  flex-direction: row;
+
+  label {
+    font-weight: normal;
+  }
 }
 
 #city-choice {
-  font-size: 20px;
-  padding: 3px 5px;
   border: 2px solid rgba(0, 0, 0, 0.2);
   border-radius: 10px;
+  color: black;
 }
 
-div.banners {
-  background-color: #4d4d4d;
-  position: absolute;
-  top: 0;
-  z-index: 2001;
-  text-align: center;
-  width: 100%;
-  left: 0;
-  padding: 10px 15px;
-}
-
-div.banner-title,
-div.banner-icons {
-  font-weight: bold;
-  border: none;
-  font-size: 20px;
-  background-color: #4d4d4d;
-  color: white;
-  float: right;
-  right: 2px;
-}
-
-.banner-about-icon {
+.header-about-icon {
   display: inline;
+
+  svg {
+    margin-right: 10px;
+  }
 }
 
-div.banner-icons {
+.header-icons {
   cursor: pointer;
-}
 
-div.banner-icons svg {
-  color: white;
-}
-
-div.banner-icons svg.fa-circle-info {
-  margin-right: 10px;
-}
-
-#tier-dropdown label {
-  font-weight: bold;
-  border: none;
-  font-size: 20px;
-  background-color: #4d4d4d;
-  color: white;
-}
-
-div.banner-title {
-  left: 4px;
-  text-align: left;
-  float: left;
-}
-
-@media only screen and (max-width: 625px) {
-  div.banners {
-    height: 65px;
-    padding-left: 10px;
-    padding-right: 10px;
-  }
-
-  div.banner-title {
-    font-size: 16px;
-  }
-
-  fieldset#tier-dropdown {
-    position: absolute;
-    left: 10px;
-    top: 35px;
-    z-index: 2005;
-  }
-
-  fieldset#tier-dropdown label {
-    font-size: 14px;
-  }
-
-  #city-choice {
-    font-size: 14px;
-    padding: 0;
+  svg {
+    color: white;
   }
 }

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -19,7 +19,7 @@ header {
   }
 
   .header-about-icon {
-    margin-right: 0.5em;
+    margin-right: 0.75em;
   }
 }
 

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -1,57 +1,52 @@
 header {
   width: 100%;
-  padding: 0.25em 1em;
+  padding: 0.4em 1em;
 
   background-color: #4d4d4d;
   color: white;
-  font-size: 1.4em;
+  font-size: 1.3em;
 
   display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  flex-direction: column;
+}
 
-  @media only screen and (min-width: 48em) {
-    flex-direction: row;
+.header-icons {
+  display: flex;
+
+  cursor: pointer;
+
+  svg {
+    color: white;
+  }
+
+  .header-about-icon {
+    margin-right: 0.5em;
+  }
+}
+
+@media only screen and (min-width: 48em) {
+  header {
+    align-items: center;
     font-size: 1.75em;
   }
-}
 
-.site-title {
-  text-align: center;
+  .navigation {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    margin-right: 1em;
+  }
 
-  @media only screen and (min-width: 48em) {
-    text-align: left;
+  .site-title {
+    flex: 1;
   }
 }
 
-.site-controls {
-  display: flex;
-  flex-direction: row;
-
-  label {
-    font-weight: normal;
-  }
+#city-dropdown label {
+  font-weight: normal;
 }
 
 #city-choice {
   border: 2px solid rgba(0, 0, 0, 0.2);
   border-radius: 10px;
   color: black;
-}
-
-.header-about-icon {
-  display: inline;
-
-  svg {
-    margin-right: 10px;
-  }
-}
-
-.header-icons {
-  cursor: pointer;
-
-  svg {
-    color: white;
-  }
 }

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -63,7 +63,7 @@ const addCitiesToToggle = (initialCityId, fallbackCityId) => {
  */
 const setUpAbout = () => {
   const aboutElement = document.querySelector(".about-text-popup");
-  document.querySelector(".banner-about-icon").addEventListener("click", () => {
+  document.querySelector(".header-about-icon").addEventListener("click", () => {
     aboutElement.style.display =
       aboutElement.style.display !== "block" ? "block" : "none";
   });

--- a/tests/app/setUpSite.test.js
+++ b/tests/app/setUpSite.test.js
@@ -159,7 +159,7 @@ test.describe("the share feature", () => {
 test("about popup can be opened and closed", async ({ page }) => {
   await page.goto("");
 
-  const aboutIcon = ".banner-about-icon";
+  const aboutIcon = ".header-about-icon";
 
   const aboutIsVisible = async (expected) => {
     const isVisible = await page.$eval(


### PR DESCRIPTION
Flexbox results in much more robust responsiveness, i.e. support for different screen sizes. Note in the pictures how the grey background didn't work properly before on mobile.

This PR also gets rid of bolding in the header because it makes the site look less professional.

## Before

<img width="287" alt="Captura de pantalla 2023-08-15 a la(s) 4 50 56 p m" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/96b9c10f-3cb8-44c6-9e07-62b22fa2ab50">

<img width="676" alt="Captura de pantalla 2023-08-15 a la(s) 4 51 10 p m" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/dafec20a-397d-4594-aa59-85cbe66a1746">

## After

<img width="285" alt="Captura de pantalla 2023-08-15 a la(s) 4 51 29 p m" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/74bcd975-da5f-4c9a-9e3c-a1631c9a25b7">

<img width="675" alt="Captura de pantalla 2023-08-15 a la(s) 4 51 46 p m" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/0fede432-8568-4d25-90a7-13890afd63c5">
