### PR TITLE
Fix map being hidden by header

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -7,15 +7,19 @@
 
 @import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");
 
+html,
 body {
   padding: 0;
   margin: 0;
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-html,
-body,
 #map {
-  height: 100%;
+  flex: 1;
   width: 100%;
 }
 


### PR DESCRIPTION
You could see the issue by setting `z-index: 3000;` on `#map`, which would cover the header.