### PR TITLE
Refactor updating scorecard

### DIFF
--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -162,8 +162,7 @@ const generateScorecard = (scoreCardEntry) => {
  * Centers view to city.
  *
  * @param map: The Leaflet map instance.
- * @param cityProperties: An object with a `layout` key (Leaflet value) and keys
- *    representing the score card properties stored in `score-cards.json`.
+ * @param layer: The Leaflet layer with the city boundaries to snap to.
  */
 const snapToCity = async (map, layer) => {
   map.fitBounds(layer.getBounds());

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -159,18 +159,27 @@ const generateScorecard = (scoreCardEntry) => {
 };
 
 /**
- * Move the map to the city boundaries and set its score card.
+ * Centers view to city.
+ *
+ * @param map: The Leaflet map instance.
+ * @param cityProperties: An object with a `layout` key (Leaflet value) and keys
+ *    representing the score card properties stored in `score-cards.json`.
+ */
+const snapToCity = async (map, cityProperties) => {
+  const { layer } = cityProperties;
+  map.fitBounds(layer.getBounds());
+};
+
+/**
+ * Set scorecard to city.
  *
  * @param map: The Leaflet map instance.
  * @param cityId: E.g. `columbus-oh`.
  * @param cityProperties: An object with a `layout` key (Leaflet value) and keys
  *    representing the score card properties stored in `score-cards.json`.
  */
-const setMapToCity = (map, cityId, cityProperties, toFitBounds = true) => {
+const setScorecard = (cityId, cityProperties) => {
   const { layer } = cityProperties;
-  if (toFitBounds) {
-    map.fitBounds(layer.getBounds());
-  }
   const scorecard = generateScorecard(cityProperties);
   setUpShareUrlClickListener(cityId);
   const popup = new Popup({
@@ -199,7 +208,7 @@ const setUpAutoScorecard = (map, cities) => {
     });
     if (centralCity) {
       document.getElementById("city-choice").value = centralCity;
-      setMapToCity(map, centralCity, cities[centralCity], false);
+      setScorecard(centralCity, cities[centralCity]);
     }
   });
 };
@@ -230,7 +239,7 @@ const setUpCitiesLayer = async (map) => {
   const cityToggleElement = document.getElementById("city-choice");
   cityToggleElement.addEventListener("change", () => {
     const cityId = cityToggleElement.value;
-    setMapToCity(map, cityId, cities[cityId]);
+    snapToCity(map, cities[cityId]);
   });
 
   // Set up map to update when user clicks within a city's boundary
@@ -239,14 +248,15 @@ const setUpCitiesLayer = async (map) => {
     if (currentZoom > 7) {
       const cityId = e.sourceTarget.feature.properties.id;
       cityToggleElement.value = cityId;
-      setMapToCity(map, cityId, cities[cityId]);
+      snapToCity(map, cities[cityId]);
     }
   });
 
   // Load initial city.
   const cityId = cityToggleElement.value;
-  setMapToCity(map, cityId, cities[cityId]);
   setUpAutoScorecard(map, cities);
+  snapToCity(map, cities[cityId]);
+  setScorecard(cityId, cities[cityId]);
 };
 
 const setUpParkingLotsLayer = async (map) => {

--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -165,8 +165,7 @@ const generateScorecard = (scoreCardEntry) => {
  * @param cityProperties: An object with a `layout` key (Leaflet value) and keys
  *    representing the score card properties stored in `score-cards.json`.
  */
-const snapToCity = async (map, cityProperties) => {
-  const { layer } = cityProperties;
+const snapToCity = async (map, layer) => {
   map.fitBounds(layer.getBounds());
 };
 
@@ -239,7 +238,7 @@ const setUpCitiesLayer = async (map) => {
   const cityToggleElement = document.getElementById("city-choice");
   cityToggleElement.addEventListener("change", () => {
     const cityId = cityToggleElement.value;
-    snapToCity(map, cities[cityId]);
+    snapToCity(map, cities[cityId].layer);
   });
 
   // Set up map to update when user clicks within a city's boundary
@@ -248,14 +247,14 @@ const setUpCitiesLayer = async (map) => {
     if (currentZoom > 7) {
       const cityId = e.sourceTarget.feature.properties.id;
       cityToggleElement.value = cityId;
-      snapToCity(map, cities[cityId]);
+      snapToCity(map, cities[cityId].layer);
     }
   });
 
   // Load initial city.
   const cityId = cityToggleElement.value;
   setUpAutoScorecard(map, cities);
-  snapToCity(map, cities[cityId]);
+  snapToCity(map, cities[cityId].layer);
   setScorecard(cityId, cities[cityId]);
 };
 


### PR DESCRIPTION
Why this refactor?
This simplifies when scorecard updates. 

Before, there were many different cases in which a scorecard would update, like the dropdown changing, the user panning to a different city, or the user clicking on a city. 
Now, the scorecard only updates to the city closes to the center of the screen. So, when the dropdown changes, the map snaps to city, which will also automatically update the scorecard.