### PR TITLE
Add more accessible font to prevent autozoom on iOs

### DIFF
--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -71,6 +71,10 @@ header {
   height: 40px;
 }
 
+.choices__input {
+  font-size: 16px;
+}
+
 .choices__list--dropdown,
 .choices__list[aria-expanded] {
   z-index: 1001;

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -72,6 +72,11 @@ header {
 }
 
 .choices__input {
+  /*
+   * This is necessary to prevent autozoom on iOS 
+   * for accessibility reasons.  See:
+   * https://weblog.west-wind.com/posts/2023/Apr/17/Preventing-iOS-Safari-Textbox-Zooming
+   */
   font-size: 16px;
 }
 


### PR DESCRIPTION
See: https://github.com/ParkingReformNetwork/parking-lot-map/issues/177

IOs on mobile autozooms for fonts in input elements < 16px for accessibility reasons.

This issue does not show up in devtools, use https://ngrok.com/ to try this out on your mobile phone.

If you don't have an iphone please test with your android or other smartphone (if you have one) as this would be useful data as well.
