### PR TITLE
Remove redundant "select a city" label

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,15 +74,13 @@
     <header>
       <div class="navigation">
         <span class="site-title">Parking Lot Map</span>
-        <fieldset id="city-dropdown">
-          <label for="city-choice">Select a city: </label>
-          <select
-            single
-            name="city-choice"
-            class="city-choice"
-            id="city-choice"
-          ></select>
-        </fieldset>
+        <select
+          single
+          name="city-dropdown"
+          class="city-dropdown"
+          id="city-dropdown"
+          aria-label="select the city"
+        ></select>
       </div>
       <div class="header-icons">
         <div class="header-about-icon">

--- a/src/css/_about.scss
+++ b/src/css/_about.scss
@@ -19,7 +19,7 @@ div.about-text-popup {
 }
 
 div.about-text-popup svg.fa-circle-xmark {
-  color: #4d4d4d;
+  color: colors.$gray-light;
 }
 
 div.about-text-container {

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -49,12 +49,7 @@ header {
     align-items: center;
     gap: 0.7em;
     height: 40px;
-    margin-bottom: 6px;
   }
-}
-
-#city-dropdown label {
-  font-weight: normal;
 }
 
 .choices__inner {

--- a/src/js/dropdown.ts
+++ b/src/js/dropdown.ts
@@ -3,7 +3,7 @@ import "choices.js/public/assets/styles/choices.css";
 import scoreCardsData from "../../data/score-cards.json";
 import { CityId, ScoreCardDetails, dropdownChoice } from "./types";
 
-export const DROPDOWN = new Choices("#city-choice", {
+export const DROPDOWN = new Choices("#city-dropdown", {
   allowHTML: false,
   itemSelectText: "Select",
   searchEnabled: true,

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -231,7 +231,7 @@ const setUpCitiesLayer = async (
   allBoundaries.addTo(map);
 
   // Set up map to update when city selection changes.
-  const cityToggleElement = document.getElementById("city-choice");
+  const cityToggleElement = document.getElementById("city-dropdown");
   if (cityToggleElement instanceof HTMLSelectElement) {
     cityToggleElement.addEventListener("change", async () => {
       const cityId = cityToggleElement.value;
@@ -260,7 +260,7 @@ const setUpCitiesLayer = async (
     snapToCity(map, cities[cityId].layer);
     setScorecard(cityId, cities[cityId]);
   } else {
-    throw new Error("#city-choice is not a select element");
+    throw new Error("#city-dropdown is not a select element");
   }
 };
 

--- a/tests/app/setUpSite.test.ts
+++ b/tests/app/setUpSite.test.ts
@@ -59,7 +59,7 @@ test("correctly load the city score card", async ({ page }) => {
 
   const [content, cityToggleValue] = await page.evaluate(() => {
     const cityChoice: HTMLSelectElement | null =
-      document.querySelector("#city-choice");
+      document.querySelector("#city-dropdown");
     const cityToggle = cityChoice?.value;
 
     const detailsTitles = Array.from(
@@ -138,7 +138,7 @@ test.describe("the share feature", () => {
       );
       const title = titlePopup?.textContent;
       const cityChoice: HTMLSelectElement | null =
-        document.querySelector("#city-choice");
+        document.querySelector("#city-dropdown");
       const cityToggle = cityChoice?.value;
       return [title, cityToggle];
     });
@@ -161,7 +161,7 @@ test.describe("the share feature", () => {
 
       const title = titlePopup?.textContent;
       const cityChoiceSelector: HTMLSelectElement | null =
-        document.querySelector("#city-choice");
+        document.querySelector("#city-dropdown");
       const cityToggle = cityChoiceSelector?.value;
       return [title, cityToggle];
     });
@@ -257,7 +257,7 @@ test("scorecard pulls up city closest to center", async ({ page }) => {
     const titlePopup = document.querySelector(".leaflet-popup-content .title");
     const title = titlePopup?.textContent;
     const cityChoice: HTMLSelectElement | null =
-      document.querySelector("#city-choice");
+      document.querySelector("#city-dropdown");
     return [title, cityChoice?.value];
   });
   expect(scoreCardTitle).toEqual("Birmingham, AL");


### PR DESCRIPTION
With the new choices.js dropdown, it's reasonably obvious what the city dropdown is for. 

The label takes up valuable screen real estate. It also adds noise to the information hierarchy, reducing attention to the other UI elements.

<details><summary>before: mobile</summary>

<img width="376" alt="Screenshot 2024-06-30 at 10 01 15 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/0d047eaf-809f-4c0c-bd48-f5aa1f41bcc8">
</details>


<details><summary>before: desktop</summary>

<img width="974" alt="Screenshot 2024-06-30 at 10 00 01 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/4f1198ac-5601-4381-b385-540ed8faf778">
</details>


<details><summary>after: mobile</summary>

<img width="374" alt="Screenshot 2024-06-30 at 10 00 47 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/2b7153b6-1f35-4bd3-8b88-f4421f53202f">
</details>


<details><summary>after: desktop</summary>

<img width="973" alt="Screenshot 2024-06-30 at 9 58 42 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/f092bb46-edbc-45f2-a9df-4132d997c019">
</details>

We still might want to redesign the header for mobile, but this is a good first step.