### PR TITLE
Increase size of zoom controls

### DIFF
--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -1,18 +1,33 @@
+@use "theme/touchable-icons";
+@use "theme/typography";
+
 .leaflet-top.leaflet-left {
-  top: 0.8rem;
+  top: 10px;
+
+  a {
+    width: touchable-icons.$min-touch-target;
+    height: touchable-icons.$min-touch-target;
+    font-size: typography.$font-size-lg;
+    font-weight: normal;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }
 
 .leaflet-touch .leaflet-control-layers-toggle {
-  width: 30px;
-  height: 30px;
+  width: touchable-icons.$min-touch-target;
+  height: touchable-icons.$min-touch-target;
 }
 
 #map > div.leaflet-control-container > div.leaflet-top.leaflet-right {
-  top: 8rem;
+  top: 100px;
   margin-left: 10px;
   right: auto;
 }
 
-.leaflet-control-layers {
-  font-size: 12px;
+.leaflet-control-layers label {
+  font-size: typography.$font-size-base;
+  font-weight: normal;
 }

--- a/src/css/theme/_touchable-icons.scss
+++ b/src/css/theme/_touchable-icons.scss
@@ -1,0 +1,40 @@
+$icon-size-xs: 20px;
+$icon-size-sm: 24px;
+$icon-size-md: 32px;
+
+// https://www.w3.org/WAI/WCAG21/Understanding/target-size.html recommends
+// 44px, but 40px takes less space.
+$min-touch-target: 40px;
+
+@mixin touchable-icon($icon-size) {
+  width: $icon-size;
+  height: $icon-size;
+
+  // Ensure minimum touch target size
+  $touch-size: max($icon-size, $min-touch-target);
+  min-width: $touch-size;
+  min-height: $touch-size;
+
+  // Center the icon within the touch target
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  // Add padding if icon is smaller than min touch target
+  @if $icon-size < $min-touch-target {
+    $padding: ($min-touch-target - $icon-size) / 2;
+    padding: $padding;
+  }
+}
+
+@mixin touchable-icon-xs {
+  @include touchable-icon($icon-size-xs);
+}
+
+@mixin touchable-icon-sm {
+  @include touchable-icon($icon-size-sm);
+}
+
+@mixin touchable-icon-md {
+  @include touchable-icon($icon-size-md);
+}


### PR DESCRIPTION
Our zoom controls were too small. Touch targets should ideally be 44px x 44px. We had 30px x 30px. I went with 40px for now as a compromise to save space - we could increase to 44 after everything is redesigned.

This also increases the font size of the layer toggle.

Finally, the PR adds code for icons, although it's not yet used. It sets the minimum icon size as 20px x 20px, whereas we had 16px x 16px before. Claude generated this Sass code.

<details><summary>before</summary>

<img width="193" alt="Screenshot 2024-07-01 at 10 45 01 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/8969d44f-3b55-47fb-bda3-a8bdc2531b07">
</details>


<details><summary>after</summary>

<img width="191" alt="Screenshot 2024-07-01 at 10 43 57 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/e7f98d4c-f96b-4713-bb77-1ac4aa04f46a">
</details>