### PR TITLE
Revamp header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,20 +72,28 @@
 
   <body>
     <header>
-      <div class="navigation">
-        <span class="site-title">Parking Lot Map</span>
-        <select
-          single
-          name="city-dropdown"
-          class="city-dropdown"
-          id="city-dropdown"
-          aria-label="select the city"
-        ></select>
-      </div>
+      <select
+        single
+        name="city-dropdown"
+        class="header-dropdown"
+        id="city-dropdown"
+        aria-label="select the city"
+      ></select>
       <div class="header-icons">
         <div class="header-about-icon-container">
           <i class="fa-solid fa-circle-info" title="About"></i>
         </div>
+        <a href="#" class="header-share-icon-container"
+          ><i
+            class="share-link-icon fa-solid fa-link fa-lg"
+            title="copy link"
+          ></i
+          ><i
+            class="share-check-icon fa-solid fa-check fa-lg"
+            title="link successfully copied"
+            style="display: none"
+          ></i>
+        </a>
         <a
           class="header-link-icon-container"
           href="https://parkingreform.org/parking-lot-map/"

--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -1,9 +1,10 @@
 @use "theme/colors";
 @use "theme/touchable-icons";
 @use "theme/typography";
+@use "header";
 
 $label-font-size: typography.$font-size-md;
-$zoom-controls-top-offset: 10px;
+$zoom-controls-top-offset: calc(70px - header.$header-height);
 $outer-border-thickness: 2px;
 $option-divider: 1px solid colors.$gray-light-translucent;
 

--- a/src/css/_donate.scss
+++ b/src/css/_donate.scss
@@ -1,25 +1,27 @@
+@use "theme/breakpoints";
+
 div.donate-button {
   position: absolute;
-  border-radius: 5px;
-  left: 9px;
-  bottom: 19px;
+  left: 10px;
   z-index: 2001;
-  width: 100px;
-}
 
-div.donate-button a img {
-  width: 100%;
-  border-radius: 4px;
-}
-
-@media only screen and (max-width: 830px) {
-  div.donate-button {
-    bottom: 43px;
+  // `bottom` is set so high to avoid covering the attribution
+  // on small screens, since it wraps to two lines.
+  bottom: 35px;
+  @include breakpoints.gt-xs {
+    bottom: 10px;
   }
-}
 
-@media only screen and (max-width: 480px) {
-  div.donate-button a img {
-    width: 70%;
+  width: 90px;
+  @include breakpoints.gt-sm {
+    width: 105px;
+  }
+  @include breakpoints.gt-md {
+    width: 120px;
+  }
+
+  a img {
+    width: 100%;
+    border-radius: 4px;
   }
 }

--- a/src/css/_donate.scss
+++ b/src/css/_donate.scss
@@ -16,9 +16,6 @@ div.donate-button {
   @include breakpoints.gt-sm {
     width: 105px;
   }
-  @include breakpoints.gt-md {
-    width: 120px;
-  }
 
   a img {
     width: 100%;

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -3,9 +3,6 @@
 @use "theme/touchable-icons";
 @use "theme/typography";
 
-// TODO:
-//  - figure out revamp of scorecard. ideally we don't have to max-height on mobile
-
 $header-y-padding: 10px;
 $header-border-bottom-size: 4px;
 $header-height: calc(

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -1,80 +1,86 @@
+@use "theme/breakpoints";
 @use "theme/colors";
+@use "theme/touchable-icons";
+@use "theme/typography";
+
+// TODO:
+//  - figure out revamp of scorecard. ideally we don't have to max-height on mobile
+
+$header-y-padding: 10px;
+$header-border-bottom-size: 4px;
+$header-height: calc(
+  touchable-icons.$min-touch-target + ($header-y-padding * 2) +
+    $header-border-bottom-size
+);
 
 header {
   width: 100%;
-  padding: 0.4em 1em;
+  display: flex;
+  align-items: center;
+
+  padding: $header-y-padding 10px;
 
   background-color: colors.$gray-light;
-  color: colors.$white;
-  font-size: 1.3em;
-
-  display: flex;
+  border-bottom: $header-border-bottom-size solid colors.$teal;
 }
 
 .header-icons {
   display: flex;
-
+  margin-left: auto;
   cursor: pointer;
+
+  .header-about-icon-container,
+  .header-share-icon-container,
+  .header-link-icon-container {
+    height: touchable-icons.$min-touch-target;
+    width: touchable-icons.$min-touch-target;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
 
   svg {
     color: colors.$white;
-  }
-
-  .header-about-icon-container {
-    margin-right: 0.75em;
-  }
-
-  margin-left: auto;
-}
-
-@media only screen and (min-width: 48em) {
-  header {
-    align-items: center;
-    font-size: 1.75em;
-  }
-
-  .navigation {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    margin-right: 1em;
-  }
-
-  .site-title {
-    flex: 1;
-  }
-
-  #city-dropdown {
-    display: flex;
-    align-items: center;
-    gap: 0.7em;
-    height: 40px;
+    height: touchable-icons.$icon-size-md;
+    width: touchable-icons.$icon-size-md;
   }
 }
 
-.choices__inner {
-  border: 2px solid colors.$black-translucent;
-  border-radius: 10px;
-  color: colors.$black;
-  height: 40px;
+.choices {
+  margin-bottom: 0;
+}
 
-  @media only screen and (min-width: 20em) {
-    min-width: 20em;
+.choices[data-type*="select-one"] {
+  .choices__inner {
+    border-radius: 10px;
+    color: colors.$black;
+    font-size: typography.$font-size-base;
+    line-height: 1.2; // To vertically center the text.
+
+    height: touchable-icons.$min-touch-target;
+
+    min-width: 220px;
+    @include breakpoints.gt-xs {
+      min-width: 300px;
+    }
+  }
+
+  .choices__input {
+    // Cannot be less than 16px due to iOS autozoom:
+    //   https://weblog.west-wind.com/posts/2023/Apr/17/Preventing-iOS-Safari-Textbox-Zooming
+    font-size: typography.$font-size-base;
   }
 }
 
-.choices__item--selectable {
-  font-size: 14px;
-  height: 40px;
+.choices__heading {
+  font-size: typography.$font-size-sm;
+  cursor: default;
 }
 
-.choices__input {
-  /*
-   * This is necessary to prevent autozoom on iOS 
-   * for accessibility reasons.  See:
-   * https://weblog.west-wind.com/posts/2023/Apr/17/Preventing-iOS-Safari-Textbox-Zooming
-   */
-  font-size: 16px;
+div.choices__item.choices__item--choice.choices__item--selectable {
+  font-size: typography.$font-size-base;
+  height: touchable-icons.$min-touch-target;
 }
 
 .choices__list--dropdown,

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -2,6 +2,7 @@
 @use "theme/colors";
 @use "theme/touchable-icons";
 @use "theme/typography";
+@use "header";
 
 $outer-padding: 15px;
 $padding-between-elements: 10px;
@@ -28,30 +29,26 @@ $border-radius: 10px;
 
   float: right;
   position: fixed;
-  right: 11px;
-  top: 100px;
+  right: 10px;
+  top: calc(header.$header-height + 12px);
 
   border-radius: $border-radius;
 }
 
-.scorecard-header {
+.scorecard-title {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top: $outer-padding;
-  padding-bottom: $padding-between-elements;
-  padding-left: $outer-padding;
-  padding-right: $outer-padding;
-}
 
-.scorecard-title {
-  flex: 1;
+  margin-top: $outer-padding;
+  margin-bottom: $padding-between-elements;
+  margin-left: $outer-padding;
+  margin-right: $outer-padding;
+  line-height: 1.1;
+
   color: colors.$teal;
   font-weight: bold;
   font-size: typography.$font-size-xl;
-  line-height: 1.1;
-  margin-top: 0;
-  margin-bottom: 0;
 }
 
 .scorecard-accordion-toggle {
@@ -106,16 +103,6 @@ $border-radius: 10px;
   margin: 0;
   padding-left: $outer-padding;
   padding-right: $outer-padding;
-}
-
-.share-icon-container {
-  margin-left: 10px;
-
-  svg {
-    color: colors.$teal !important;
-    font-size: typography.$font-size-lg;
-    padding-bottom: 2px;
-  }
 }
 
 .popup-button a {

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -1,4 +1,7 @@
+@use "theme/breakpoints";
 @use "theme/colors";
+@use "theme/typography";
+@use "header";
 
 .popup-fixed {
   position: fixed;
@@ -11,113 +14,48 @@
 }
 
 .leaflet-popup-content-wrapper {
-  width: 365px;
-  border-radius: 10px;
-  float: right;
   position: fixed;
-  right: 11px;
-  top: 70px;
+  right: 10px;
+  top: calc(header.$header-height + 10px);
+
+  width: 270px;
+  border-radius: 10px;
 }
 
-.leaflet-popup-content {
-  width: 330px;
-}
+.scorecard-title {
+  display: inline-block;
+  margin-top: 0;
+  margin-bottom: 10px;
 
-div.leaflet-popup-content-wrapper div div {
-  width: 342px;
-}
-
-div.leaflet-popup-content-wrapper > div > div.title {
   color: colors.$teal;
   font-weight: bold;
-  font-size: 16px;
+  font-size: typography.$font-size-xl;
+  line-height: 1.1;
 }
 
-div.leaflet-popup-content-wrapper div span.details-title,
-div.leaflet-popup-content-wrapper div span.details-value {
-  font-size: 14px;
+.details-title,
+.details-value {
+  font-size: typography.$font-size-base;
   color: colors.$black;
 }
 
-div.leaflet-popup-content-wrapper span.details-value {
-  color: colors.$teal;
-}
-
-div.leaflet-popup-content-wrapper > div > div.title {
-  color: colors.$teal;
-  font-weight: bold;
-  font-size: 18px;
-  display: inline-block;
-  width: 50%;
-}
-
-div.leaflet-popup-content-wrapper > div > div.url-copy-button {
-  float: right;
-  width: 0%;
-  display: inline-block;
-}
-
-div.leaflet-popup-content-wrapper > div > div.url-copy-button:hover {
-  cursor: pointer;
-}
-
-div.leaflet-popup-content-wrapper > div > div.url-copy-button svg.fa-link {
-  color: colors.$teal;
+.community-tag {
+  font-size: typography.$font-size-base;
+  color: colors.$gray;
 }
 
 div.popup-button a {
   background-color: colors.$teal;
   padding: 10px;
-  font-size: 16px;
+  font-size: typography.$font-size-base;
   color: colors.$white;
   border-radius: 8px;
-  font-weight: bold;
   text-decoration: none;
-  border: 1px solid colors.$teal;
   display: inline-block;
-}
 
-div.popup-button a:hover {
-  background-color: colors.$white;
-  color: colors.$teal;
-  border: 1px solid colors.$teal;
-}
-
-.community-tag {
-  font-size: 14px;
-  color: colors.$gray;
-}
-
-@media only screen and (max-width: 830px) {
-  .leaflet-popup-content-wrapper {
-    overflow-y: scroll;
-    overflow-x: hidden;
-    height: 119px;
-    width: 350px;
-    border-radius: 10px;
-    float: left;
-    position: fixed;
-    bottom: 32px;
-    top: auto;
-    right: 10px;
-  }
-
-  div.leaflet-popup-content-wrapper div div {
-    width: 310px;
-  }
-
-  div.leaflet-popup-content {
-    width: auto;
-  }
-}
-
-@media only screen and (max-width: 480px) {
-  .leaflet-popup-content-wrapper {
-    width: 280px;
-    bottom: 40px;
-  }
-
-  div.leaflet-popup-content-wrapper div div {
-    width: 240px;
+  &:hover {
+    background-color: colors.$white;
+    color: colors.$teal;
+    border: 1px solid colors.$teal;
   }
 }

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -4,13 +4,7 @@ import setUpShareUrlClickListener from "./share";
 
 const generateScorecard = (entry: ScoreCardDetails): string => {
   const header = `
-      <div class="scorecard-header">
-        <h1 class="scorecard-title">${entry.name}</h1>
-        <a href="#" class="share-icon-container">
-          <i class="share-link-icon fa-solid fa-link fa-xl" title="Copy link"></i>
-          <i class="share-check-icon fa-solid fa-check fa-xl" title="Link Copied!" style="display: none"></i>
-        </a>
-      </div>
+      <h1 class="scorecard-title">Parking lots in ${entry.name}</h1>
       <p>${entry.percentage} of the central city is off-street parking</p>
       `;
 

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -87,17 +87,8 @@ const createMap = (): Map => {
  * Generate the HTML for the score card.
  */
 const generateScorecard = (entry: ScoreCardDetails): string => {
-  const header = `
-    <div class="title">${entry.name}</div>
-    <div class="url-copy-button">
-      <a href="#" class="share-icon">
-        <i class="share-link-icon fa-solid fa-link fa-xl" title="Copy link"></i>
-        <i class="share-check-icon fa-solid fa-check fa-xl" title="Link Copied!" style="display: none"></i>
-      </a>
-    </div>
-    `;
-
-  const lines = ["<hr>"];
+  const header = `<h1 class="scorecard-title">Parking lots in ${entry.name}</h1>`;
+  const lines = [];
   const addEntry = (title: string, value: string): void => {
     lines.push(
       `<div><span class="details-title">${title}: </span><span class="details-value">${value}</span></div>`
@@ -123,7 +114,7 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
   if (entry.url) {
     lines.push(
       "<hr>",
-      `<div class="popup-button"><a href="${entry.url}">View more about reforms</a></div>`
+      `<div class="popup-button"><a href="${entry.url}">Reform details</a></div>`
     );
   }
   return header + lines.join("\n");

--- a/src/js/share.ts
+++ b/src/js/share.ts
@@ -26,18 +26,12 @@ const switchIcons = (shareIcon: HTMLAnchorElement): void => {
 };
 
 const setUpShareUrlClickListener = (cityId: CityId): void => {
-  // We put the event listener on `map` because it is never erased, unlike the copy button
-  // being recreated every time the score card changes. This is called "event delegation".
-  const mapElement = document.querySelector("#map");
-  if (!(mapElement instanceof Element)) return;
-  mapElement.addEventListener("click", async (event) => {
-    const copyButton = event.target;
-    if (!(copyButton instanceof Element)) return;
-    const targetElement = copyButton.closest("div.url-copy-button > a");
-    if (!(targetElement instanceof HTMLAnchorElement)) return;
+  const copyButton = document.querySelector(".header-share-icon-container");
+  if (!(copyButton instanceof HTMLAnchorElement)) return;
+  copyButton.addEventListener("click", async () => {
     const shareUrl = determineShareUrl(window.location.href, cityId);
     await copyToClipboard(shareUrl);
-    switchIcons(targetElement);
+    switchIcons(copyButton);
   });
 };
 

--- a/tests/app/setUpSite.test.ts
+++ b/tests/app/setUpSite.test.ts
@@ -52,7 +52,9 @@ test("correctly load the city score card", async ({ page }) => {
   await page.click('.choices__item--choice >> text="Albany, NY"');
   await page.waitForFunction(() => {
     const titleElement = document.querySelector(".scorecard-title");
-    return titleElement && titleElement.textContent === "Albany, NY";
+    return (
+      titleElement && titleElement.textContent === "Parking lots in Albany, NY"
+    );
   });
 
   await page.locator(".scorecard-accordion-toggle").click();
@@ -105,7 +107,10 @@ test.describe("the share feature", () => {
     await page.click('.choices__item--choice >> text="Anchorage, AK"');
     await page.waitForFunction(() => {
       const titleElement = document.querySelector(".scorecard-title");
-      return titleElement && titleElement.textContent === "Anchorage, AK";
+      return (
+        titleElement &&
+        titleElement.textContent === "Parking lots in Anchorage, AK"
+      );
     });
 
     await page.click(".header-share-icon-container");
@@ -134,7 +139,7 @@ test.describe("the share feature", () => {
       return [title, cityToggle];
     });
 
-    expect(scoreCardTitle).toEqual("Fort Worth, TX");
+    expect(scoreCardTitle).toEqual("Parking lots in Fort Worth, TX");
     expect(cityToggleValue).toEqual("fort-worth-tx");
   });
 
@@ -156,7 +161,7 @@ test.describe("the share feature", () => {
       return [title, cityToggle];
     });
 
-    expect(scoreCardTitle).toEqual("Atlanta, GA");
+    expect(scoreCardTitle).toEqual("Parking lots in Atlanta, GA");
     expect(cityToggleValue).toEqual("atlanta-ga");
   });
 });
@@ -202,7 +207,7 @@ test.describe("auto-focus city", () => {
     const newScorecard = await page
       .locator(".scorecard-title")
       .evaluate((node) => node.textContent);
-    expect(newScorecard).toEqual("Birmingham, AL");
+    expect(newScorecard).toEqual("Parking lots in Birmingham, AL");
     expect(await page.isVisible("#birmingham-al")).toBe(true);
   });
   test("clicking on city boundary wide view", async ({ page }) => {
@@ -225,7 +230,7 @@ test.describe("auto-focus city", () => {
     const scorecard = await page
       .locator(".scorecard-title")
       .evaluate((node) => node.textContent);
-    expect(scorecard).toEqual("Atlanta, GA");
+    expect(scorecard).toEqual("Parking lots in Atlanta, GA");
   });
 });
 
@@ -250,7 +255,7 @@ test("scorecard pulls up city closest to center", async ({ page }) => {
       document.querySelector("#city-dropdown");
     return [title, cityChoice?.value];
   });
-  expect(scoreCardTitle).toEqual("Birmingham, AL");
+  expect(scoreCardTitle).toEqual("Parking lots in Birmingham, AL");
   expect(cityToggleValue).toEqual("birmingham-al");
 });
 

--- a/tests/app/setUpSite.test.ts
+++ b/tests/app/setUpSite.test.ts
@@ -96,9 +96,9 @@ test.describe("the share feature", () => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     const page = await context.newPage();
     await page.goto("/");
-    await page.waitForSelector(".url-copy-button > a");
+    await page.waitForSelector(".header-share-icon-container");
 
-    await page.click(".url-copy-button > a");
+    await page.click(".header-share-icon-container");
     const firstCityClipboardText = await page.evaluate(() =>
       navigator.clipboard.readText()
     );
@@ -116,7 +116,7 @@ test.describe("the share feature", () => {
       return titleElement && titleElement.textContent === "Anchorage, AK";
     });
 
-    await page.click(".url-copy-button > a");
+    await page.click(".header-share-icon-container");
     const secondCityClipboardText = await page.evaluate(() =>
       navigator.clipboard.readText()
     );


### PR DESCRIPTION
This improves the header:

* Makes all touch targets at least 44px, the accessibility minimum
* Moves copy link icon to the header
* Removes the "Parking Lot Map" text
* adds a teal border underneath

It also adds more explanatory text to the header in the scorecard, now saying "Parking lots in City, ST" to better explain what people are seeing.

<details><summary>before: mobile</summary>

<img width="377" alt="Screenshot 2024-07-07 at 4 27 36 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/8f94c488-40c1-4085-9c66-94adc49ebf4a">
</details>

<details><summary>before: desktop</summary>

<img width="1108" alt="Screenshot 2024-07-07 at 4 26 40 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/610c9d85-4fe2-4e12-bf16-0b9a11f81e10">
</details>

<details><summary>after: mobile</summary>

<img width="374" alt="Screenshot 2024-07-07 at 4 27 00 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/3254f3b5-77f9-4512-9e79-cea065ac7c42">
</details>

<details><summary>after: desktop</summary>

<img width="1114" alt="Screenshot 2024-07-07 at 4 25 55 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/3a0cdcee-4f7d-4d94-81ea-837aaa75b5a7">
</details>

--

Removing the "Parking Lot Map" text achieves two things:

* Allows us to fit the header on a single line, even on mobile. This allows more screen real estate for the map itself and scorecard
* Improves information hierarchy. The name of the map is not as important as the map itself and explaining what you're seeing on the map (i.e. the unexpanded accordion)

People will still see the name of the map because it's often accessed from the resources folder with all the additional context.

--

Finally, this improves the size and positioning of the donate button.