### PR TITLE
Refactor scorecard in preparation for accordion

### DIFF
--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -1,4 +1,5 @@
 @use "theme/colors";
+@use "theme/typography";
 
 .popup-fixed {
   position: fixed;
@@ -16,75 +17,53 @@
   float: right;
   position: fixed;
   right: 11px;
-  top: 70px;
+  top: 75px;
 }
 
-.leaflet-popup-content {
-  width: 330px;
-}
-
-div.leaflet-popup-content-wrapper div div {
-  width: 342px;
-}
-
-div.leaflet-popup-content-wrapper > div > div.title {
+.scorecard-title {
   color: colors.$teal;
   font-weight: bold;
-  font-size: 16px;
-}
-
-div.leaflet-popup-content-wrapper div span.details-title,
-div.leaflet-popup-content-wrapper div span.details-value {
-  font-size: 14px;
-  color: colors.$black;
-}
-
-div.leaflet-popup-content-wrapper span.details-value {
-  color: colors.$teal;
-}
-
-div.leaflet-popup-content-wrapper > div > div.title {
-  color: colors.$teal;
-  font-weight: bold;
-  font-size: 18px;
+  font-size: typography.$font-size-md;
   display: inline-block;
-  width: 50%;
+  width: 75%;
 }
 
-div.leaflet-popup-content-wrapper > div > div.url-copy-button {
+.leaflet-popup-content-wrapper p {
+  font-size: typography.$font-size-sm;
+  color: colors.$black;
+  margin: 0;
+}
+
+.share-icon-container-outer {
   float: right;
   width: 0%;
   display: inline-block;
-}
-
-div.leaflet-popup-content-wrapper > div > div.url-copy-button:hover {
   cursor: pointer;
+
+  .share-icon-container svg {
+    color: colors.$teal;
+  }
 }
 
-div.leaflet-popup-content-wrapper > div > div.url-copy-button svg.fa-link {
-  color: colors.$teal;
-}
-
-div.popup-button a {
+.popup-button a {
   background-color: colors.$teal;
   padding: 10px;
-  font-size: 16px;
+  font-size: typography.$font-size-base;
   color: colors.$white;
   border-radius: 8px;
-  font-weight: bold;
   text-decoration: none;
   border: 1px solid colors.$teal;
   display: inline-block;
-}
 
-div.popup-button a:hover {
-  background-color: colors.$white;
-  color: colors.$teal;
-  border: 1px solid colors.$teal;
+  &:hover {
+    background-color: colors.$white;
+    color: colors.$teal;
+    border: 1px solid colors.$teal;
+  }
 }
 
 .community-tag {
-  font-size: 14px;
+  font-size: typography.$font-size-sm;
   color: colors.$gray;
 }
 
@@ -94,20 +73,11 @@ div.popup-button a:hover {
     overflow-x: hidden;
     height: 119px;
     width: 350px;
-    border-radius: 10px;
     float: left;
     position: fixed;
     bottom: 32px;
     top: auto;
     right: 10px;
-  }
-
-  div.leaflet-popup-content-wrapper div div {
-    width: 310px;
-  }
-
-  div.leaflet-popup-content {
-    width: auto;
   }
 }
 
@@ -115,9 +85,5 @@ div.popup-button a:hover {
   .leaflet-popup-content-wrapper {
     width: 280px;
     bottom: 40px;
-  }
-
-  div.leaflet-popup-content-wrapper div div {
-    width: 240px;
   }
 }

--- a/src/js/about.ts
+++ b/src/js/about.ts
@@ -4,38 +4,39 @@
  * Set up event listeners to open and close the about popup.
  */
 const setUpAbout = () => {
-  const aboutElement: HTMLElement | null =
-    document.querySelector(".about-text-popup");
+  const aboutElement = document.querySelector(".about-text-popup");
   const infoButton = document.querySelector(".header-about-icon-container");
-  if (infoButton && aboutElement) {
-    infoButton.addEventListener("click", () => {
-      aboutElement.style.display =
-        aboutElement.style.display !== "block" ? "block" : "none";
-    });
+  if (
+    !(aboutElement instanceof HTMLElement) ||
+    !(infoButton instanceof HTMLElement)
+  )
+    return;
 
-    // closes window on clicks outside the info popup
-    window.addEventListener("click", (event: MouseEvent) => {
-      const clickTarget = event?.target as Element;
-      if (
-        !infoButton.contains(clickTarget) &&
-        aboutElement.style.display === "block" &&
-        !aboutElement.contains(clickTarget)
-      ) {
-        aboutElement.style.display = "none";
-        infoButton.classList.toggle("active");
-      }
-    });
+  infoButton.addEventListener("click", () => {
+    aboutElement.style.display =
+      aboutElement.style.display !== "block" ? "block" : "none";
+  });
 
+  // closes window on clicks outside the info popup
+  window.addEventListener("click", (event) => {
+    if (
+      event.target instanceof Element &&
+      !infoButton.contains(event.target) &&
+      aboutElement.style.display === "block" &&
+      !aboutElement.contains(event.target)
+    ) {
+      aboutElement.style.display = "none";
+      infoButton.classList.toggle("active");
+    }
+  });
+
+  const aboutClose = document.querySelector(".about-close");
+  if (!(aboutClose instanceof HTMLElement)) return;
+  aboutClose.addEventListener("click", () => {
     // Note that the close element will only render when the about text popup is rendered.
     // So, it only ever makes sense for a click to close.
-    const aboutClose: HTMLAnchorElement | null =
-      document.querySelector(".about-close");
-    if (aboutClose) {
-      aboutClose.addEventListener("click", () => {
-        aboutElement.style.display = "none";
-      });
-    }
-  }
+    aboutElement.style.display = "none";
+  });
 };
 
 export default setUpAbout;

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -88,9 +88,9 @@ const createMap = (): Map => {
  */
 const generateScorecard = (entry: ScoreCardDetails): string => {
   const header = `
-    <div class="title">${entry.name}</div>
-    <div class="url-copy-button">
-      <a href="#" class="share-icon">
+    <div class="scorecard-title">${entry.name}</div>
+    <div class="share-icon-container-outer">
+      <a href="#" class="share-icon-container">
         <i class="share-link-icon fa-solid fa-link fa-xl" title="Copy link"></i>
         <i class="share-check-icon fa-solid fa-check fa-xl" title="Link Copied!" style="display: none"></i>
       </a>
@@ -98,21 +98,17 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
     `;
 
   const lines = ["<hr>"];
-  const addEntry = (title: string, value: string): void => {
-    lines.push(
-      `<div><span class="details-title">${title}: </span><span class="details-value">${value}</span></div>`
-    );
-  };
-
-  addEntry("Parking", `${entry.percentage} of central city`);
+  lines.push(`<p>Parking: ${entry.percentage} of central city</p>`);
   if (entry.parkingScore) {
-    addEntry("Parking score", entry.parkingScore);
+    lines.push(`<p>Parking score: ${entry.parkingScore}</p>`);
   }
-  addEntry("Parking reform", entry.reforms);
+  lines.push(`<p>Parking reform: ${entry.reforms}</p>`);
   lines.push("<br />");
-  addEntry("City type", entry.cityType);
-  addEntry("Population", entry.population);
-  addEntry("Urbanized area population", entry.urbanizedAreaPopulation);
+  lines.push(`<p>City type: ${entry.cityType}</p>`);
+  lines.push(`<p>Population: ${entry.population}</p>`);
+  lines.push(
+    `<p>Urbanized area population: ${entry.urbanizedAreaPopulation}</p>`
+  );
 
   if ("contribution" in entry) {
     lines.push("<hr>");

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -232,36 +232,32 @@ const setUpCitiesLayer = async (
 
   // Set up map to update when city selection changes.
   const cityToggleElement = document.getElementById("city-dropdown");
-  if (cityToggleElement instanceof HTMLSelectElement) {
-    cityToggleElement.addEventListener("change", async () => {
-      const cityId = cityToggleElement.value;
-      const { layer } = cities[cityId];
-      if (layer) {
-        snapToCity(map, layer);
-      }
-    });
-
-    // Set up map to update when user clicks within a city's boundary
-    allBoundaries.addEventListener("click", (e) => {
-      const currentZoom = map.getZoom();
-      if (currentZoom > 7) {
-        const cityId = e.sourceTarget.feature.properties.id;
-        cityToggleElement.value = cityId;
-        const { layer } = cities[cityId];
-        if (layer) {
-          snapToCity(map, layer);
-        }
-      }
-    });
-
-    // Load initial city.
+  if (!(cityToggleElement instanceof HTMLSelectElement)) return;
+  cityToggleElement.addEventListener("change", async () => {
     const cityId = cityToggleElement.value;
-    setUpAutoScorecard(map, cities, parkingLayer);
-    snapToCity(map, cities[cityId].layer);
-    setScorecard(cityId, cities[cityId]);
-  } else {
-    throw new Error("#city-dropdown is not a select element");
-  }
+    const { layer } = cities[cityId];
+    if (layer) {
+      snapToCity(map, layer);
+    }
+  });
+
+  // Set up map to update when user clicks within a city's boundary
+  allBoundaries.addEventListener("click", (e) => {
+    const currentZoom = map.getZoom();
+    if (currentZoom <= 7) return;
+    const cityId = e.sourceTarget.feature.properties.id;
+    cityToggleElement.value = cityId;
+    const { layer } = cities[cityId];
+    if (layer) {
+      snapToCity(map, layer);
+    }
+  });
+
+  // Load initial city.
+  const cityId = cityToggleElement.value;
+  setUpAutoScorecard(map, cities, parkingLayer);
+  snapToCity(map, cities[cityId].layer);
+  setScorecard(cityId, cities[cityId]);
 };
 
 /**
@@ -277,22 +273,20 @@ const setUpParkingLotsLayer = async (
     },
   }).addTo(map);
 
+  if (window.location.href.indexOf("#lots-toggle") === -1) return parkingLayer;
+
   // If `#lots-toggle` is in the URL, we show buttons to toggle parking lots.
-  if (window.location.href.indexOf("#lots-toggle") !== -1) {
-    const toggle: HTMLAnchorElement | null =
-      document.querySelector("#lots-toggle");
-    if (toggle) {
-      toggle.style.display = "block";
-    }
-    document
-      .querySelector("#lots-toggle-off")
-      ?.addEventListener("click", () => {
-        parkingLayer.removeFrom(map);
-      });
-    document.querySelector("#lots-toggle-on")?.addEventListener("click", () => {
-      parkingLayer.addTo(map);
-    });
+  const toggle: HTMLAnchorElement | null =
+    document.querySelector("#lots-toggle");
+  if (toggle) {
+    toggle.style.display = "block";
   }
+  document.querySelector("#lots-toggle-off")?.addEventListener("click", () => {
+    parkingLayer.removeFrom(map);
+  });
+  document.querySelector("#lots-toggle-on")?.addEventListener("click", () => {
+    parkingLayer.addTo(map);
+  });
   return parkingLayer;
 };
 

--- a/src/js/share.ts
+++ b/src/js/share.ts
@@ -33,7 +33,7 @@ const setUpShareUrlClickListener = (cityId: CityId): void => {
   mapElement.addEventListener("click", async (event) => {
     const copyButton = event.target;
     if (!(copyButton instanceof Element)) return;
-    const targetElement = copyButton.closest("div.url-copy-button > a");
+    const targetElement = copyButton.closest(".share-icon-container");
     if (!(targetElement instanceof HTMLAnchorElement)) return;
     const shareUrl = determineShareUrl(window.location.href, cityId);
     await copyToClipboard(shareUrl);

--- a/src/js/share.ts
+++ b/src/js/share.ts
@@ -12,41 +12,33 @@ const copyToClipboard = async (value: string): Promise<void> => {
 };
 
 const switchIcons = (shareIcon: HTMLAnchorElement): void => {
-  const linkIcon: HTMLAnchorElement | null = shareIcon.querySelector(
-    "svg.share-link-icon"
-  );
-  const checkIcon: HTMLAnchorElement | null = shareIcon.querySelector(
-    "svg.share-check-icon"
-  );
-  if (linkIcon && checkIcon) {
-    linkIcon.style.display = "none";
-    checkIcon.style.display = "inline-block";
-    setTimeout(() => {
-      linkIcon.style.display = "inline-block";
-      checkIcon.style.display = "none";
-    }, 1000);
-  }
+  const linkIcon = shareIcon.querySelector("svg.share-link-icon");
+  const checkIcon = shareIcon.querySelector("svg.share-check-icon");
+  if (!(linkIcon instanceof SVGElement) || !(checkIcon instanceof SVGElement))
+    return;
+
+  linkIcon.style.display = "none";
+  checkIcon.style.display = "inline-block";
+  setTimeout(() => {
+    linkIcon.style.display = "inline-block";
+    checkIcon.style.display = "none";
+  }, 1000);
 };
 
 const setUpShareUrlClickListener = (cityId: CityId): void => {
   // We put the event listener on `map` because it is never erased, unlike the copy button
   // being recreated every time the score card changes. This is called "event delegation".
-  const mapElement: HTMLElement | null = document.querySelector("#map");
-  if (mapElement) {
-    mapElement.addEventListener("click", async (event: MouseEvent | null) => {
-      const copyButton = event?.target as Element;
-      if (copyButton) {
-        const targetElement: HTMLAnchorElement | null = copyButton.closest(
-          "div.url-copy-button > a"
-        );
-        if (targetElement) {
-          const shareUrl = determineShareUrl(window.location.href, cityId);
-          await copyToClipboard(shareUrl);
-          switchIcons(targetElement);
-        }
-      }
-    });
-  }
+  const mapElement = document.querySelector("#map");
+  if (!(mapElement instanceof Element)) return;
+  mapElement.addEventListener("click", async (event) => {
+    const copyButton = event.target;
+    if (!(copyButton instanceof Element)) return;
+    const targetElement = copyButton.closest("div.url-copy-button > a");
+    if (!(targetElement instanceof HTMLAnchorElement)) return;
+    const shareUrl = determineShareUrl(window.location.href, cityId);
+    await copyToClipboard(shareUrl);
+    switchIcons(targetElement);
+  });
 };
 
 export default setUpShareUrlClickListener;

--- a/tests/app/setUpSite.test.ts
+++ b/tests/app/setUpSite.test.ts
@@ -61,10 +61,12 @@ test("correctly load the city score card", async ({ page }) => {
     const cityToggle = cityChoice?.value;
 
     const keysToValues: Record<string, string> = {};
+    // eslint-disable-next-line no-restricted-syntax
     for (const el of document.querySelectorAll(
       ".leaflet-popup-content-wrapper p"
     )) {
       const split = el.textContent?.split(":", 2);
+      // eslint-disable-next-line no-continue
       if (!split) continue;
       const [k, v] = split;
       keysToValues[k] = v.trim();
@@ -73,10 +75,10 @@ test("correctly load the city score card", async ({ page }) => {
   });
 
   expect(cityToggleValue).toEqual("albany-ny");
-  expect(content["Parking"]).toEqual(
+  expect(content.Parking).toEqual(
     `${albanyExpected.percentage} of central city`
   );
-  expect(content["Population"]).toEqual(albanyExpected.population);
+  expect(content.Population).toEqual(albanyExpected.population);
   expect(content["Urbanized area population"]).toEqual(
     albanyExpected.urbanizedAreaPopulation
   );

--- a/tests/app/setUpSite.test.ts
+++ b/tests/app/setUpSite.test.ts
@@ -51,9 +51,7 @@ test("correctly load the city score card", async ({ page }) => {
   await page.click(".choices");
   await page.click('.choices__item--choice >> text="Albany, NY"');
   await page.waitForFunction(() => {
-    const titleElement = document.querySelector(
-      ".leaflet-popup-content .title"
-    );
+    const titleElement = document.querySelector(".scorecard-title");
     return titleElement && titleElement.textContent === "Albany, NY";
   });
 
@@ -62,31 +60,28 @@ test("correctly load the city score card", async ({ page }) => {
       document.querySelector("#city-dropdown");
     const cityToggle = cityChoice?.value;
 
-    const detailsTitles = Array.from(
-      document.querySelectorAll(".leaflet-popup-content .details-title")
-    ).map((el) => el.textContent);
-    const detailsValues = Array.from(
-      document.querySelectorAll(".leaflet-popup-content .details-value")
-    ).map((el) => el.textContent);
-
-    const details: Record<string, string | null> = {};
-    detailsTitles.forEach((title, index) => {
-      if (title) {
-        details[title] = detailsValues[index];
-      }
-    });
-    return [details, cityToggle];
+    const keysToValues: Record<string, string> = {};
+    for (const el of document.querySelectorAll(
+      ".leaflet-popup-content-wrapper p"
+    )) {
+      const split = el.textContent?.split(":", 2);
+      if (!split) continue;
+      const [k, v] = split;
+      keysToValues[k] = v.trim();
+    }
+    return [keysToValues, cityToggle];
   });
+
   expect(cityToggleValue).toEqual("albany-ny");
-  expect(content["Parking: "]).toEqual(
+  expect(content["Parking"]).toEqual(
     `${albanyExpected.percentage} of central city`
   );
-  expect(content["Population: "]).toEqual(albanyExpected.population);
-  expect(content["Urbanized area population: "]).toEqual(
+  expect(content["Population"]).toEqual(albanyExpected.population);
+  expect(content["Urbanized area population"]).toEqual(
     albanyExpected.urbanizedAreaPopulation
   );
-  expect(content["Parking score: "]).toEqual(albanyExpected.parkingScore);
-  expect(content["Parking reform: "]).toEqual(albanyExpected.reforms);
+  expect(content["Parking score"]).toEqual(albanyExpected.parkingScore);
+  expect(content["Parking reform"]).toEqual(albanyExpected.reforms);
   expect(albanyLoaded).toBe(true);
 });
 
@@ -96,9 +91,9 @@ test.describe("the share feature", () => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     const page = await context.newPage();
     await page.goto("/");
-    await page.waitForSelector(".url-copy-button > a");
+    await page.waitForSelector(".share-icon-container");
 
-    await page.click(".url-copy-button > a");
+    await page.click(".share-icon-container");
     const firstCityClipboardText = await page.evaluate(() =>
       navigator.clipboard.readText()
     );
@@ -110,13 +105,11 @@ test.describe("the share feature", () => {
     await page.click(".choices");
     await page.click('.choices__item--choice >> text="Anchorage, AK"');
     await page.waitForFunction(() => {
-      const titleElement = document.querySelector(
-        ".leaflet-popup-content .title"
-      );
+      const titleElement = document.querySelector(".scorecard-title");
       return titleElement && titleElement.textContent === "Anchorage, AK";
     });
 
-    await page.click(".url-copy-button > a");
+    await page.click(".share-icon-container");
     const secondCityClipboardText = await page.evaluate(() =>
       navigator.clipboard.readText()
     );
@@ -130,12 +123,11 @@ test.describe("the share feature", () => {
     await page.goto("#parking-reform-map=fort-worth-tx");
 
     // Wait a second to make sure the site is fully loaded.
-    await page.waitForSelector(".leaflet-popup-content .title");
+    await page.waitForSelector(".scorecard-title");
 
     const [scoreCardTitle, cityToggleValue] = await page.evaluate(() => {
-      const titlePopup: HTMLElement | null = document.querySelector(
-        ".leaflet-popup-content .title"
-      );
+      const titlePopup: HTMLElement | null =
+        document.querySelector(".scorecard-title");
       const title = titlePopup?.textContent;
       const cityChoice: HTMLSelectElement | null =
         document.querySelector("#city-dropdown");
@@ -155,9 +147,8 @@ test.describe("the share feature", () => {
     // Wait a second to make sure the site is fully loaded.
     await page.waitForTimeout(1000);
     const [scoreCardTitle, cityToggleValue] = await page.evaluate(() => {
-      const titlePopup: HTMLAnchorElement | null = document.querySelector(
-        ".leaflet-popup-content .title"
-      );
+      const titlePopup: HTMLAnchorElement | null =
+        document.querySelector(".scorecard-title");
 
       const title = titlePopup?.textContent;
       const cityChoiceSelector: HTMLSelectElement | null =
@@ -210,7 +201,7 @@ test.describe("auto-focus city", () => {
     await page.waitForTimeout(1000);
 
     const newScorecard = await page
-      .locator(".leaflet-popup-content .title")
+      .locator(".scorecard-title")
       .evaluate((node) => node.textContent);
     expect(newScorecard).toEqual("Birmingham, AL");
     expect(await page.isVisible("#birmingham-al")).toBe(true);
@@ -233,7 +224,7 @@ test.describe("auto-focus city", () => {
     await page.waitForTimeout(1000);
 
     const scorecard = await page
-      .locator(".leaflet-popup-content .title")
+      .locator(".scorecard-title")
       .evaluate((node) => node.textContent);
     expect(scorecard).toEqual("Atlanta, GA");
   });
@@ -254,7 +245,7 @@ test("scorecard pulls up city closest to center", async ({ page }) => {
 
   await page.waitForSelector(".choices");
   const [scoreCardTitle, cityToggleValue] = await page.evaluate(() => {
-    const titlePopup = document.querySelector(".leaflet-popup-content .title");
+    const titlePopup = document.querySelector(".scorecard-title");
     const title = titlePopup?.textContent;
     const cityChoice: HTMLSelectElement | null =
       document.querySelector("#city-dropdown");


### PR DESCRIPTION
This PR:

* removes a bunch of unnecessary CSS rules
* renames some classes to be more clear
* replaces the HTML structure of `.details-title: .details-key` to instead be a `<p>`, since we want to move away from the `key: value` format in the scorecard

The end user interface is roughly the same as before; this is mostly a refactor.