### PR TITLE
Use flexbox for scorecard header

### DIFF
--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -12,7 +12,7 @@
 }
 
 .leaflet-popup-content-wrapper {
-  width: 365px;
+  width: 330px;
   border-radius: 10px;
   float: right;
   position: fixed;
@@ -34,7 +34,7 @@
 }
 
 .leaflet-popup-content-wrapper p {
-  font-size: typography.$font-size-sm;
+  font-size: typography.$font-size-base;
   color: colors.$black;
   margin: 0;
 }
@@ -74,7 +74,6 @@
     overflow-y: scroll;
     overflow-x: hidden;
     height: 119px;
-    width: 350px;
     float: left;
     position: fixed;
     bottom: 32px;

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -20,12 +20,17 @@
   top: 75px;
 }
 
+.scorecard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .scorecard-title {
+  flex: 1;
   color: colors.$teal;
   font-weight: bold;
   font-size: typography.$font-size-md;
-  display: inline-block;
-  width: 75%;
 }
 
 .leaflet-popup-content-wrapper p {
@@ -34,14 +39,11 @@
   margin: 0;
 }
 
-.share-icon-container-outer {
-  float: right;
-  width: 0%;
-  display: inline-block;
-  cursor: pointer;
+.share-icon-container {
+  margin-left: 10px;
 
-  .share-icon-container svg {
-    color: colors.$teal;
+  svg {
+    color: colors.$teal !important;
   }
 }
 

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -88,8 +88,8 @@ const createMap = (): Map => {
  */
 const generateScorecard = (entry: ScoreCardDetails): string => {
   const header = `
-    <div class="scorecard-title">${entry.name}</div>
-    <div class="share-icon-container-outer">
+    <div class="scorecard-header">
+      <div class="scorecard-title">${entry.name}</div>
       <a href="#" class="share-icon-container">
         <i class="share-link-icon fa-solid fa-link fa-xl" title="Copy link"></i>
         <i class="share-check-icon fa-solid fa-check fa-xl" title="Link Copied!" style="display: none"></i>


### PR DESCRIPTION
Even though I'll be proposing moving the share link icon to the top header, it will still be in the scorecard as part of the initial accordion revamp. So it's important that the styling is right.

This uses flexbox so that the share link icon is always positioned in the correct spot, whereas using `float` was haphazard.

It also allows us to shrink the width of the scorecard.