### PR TITLE
Use an accordion for scorecard

### DIFF
--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -2,9 +2,6 @@
 @use "theme/touchable-icons";
 @use "theme/typography";
 
-// TODO:
-//  - accessibility (aria)
-
 $outer-padding: 15px;
 $padding-between-elements: 10px;
 $border-radius: 10px;

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -1,5 +1,13 @@
 @use "theme/colors";
+@use "theme/touchable-icons";
 @use "theme/typography";
+
+// TODO:
+//  - accessibility (aria)
+
+$outer-padding: 15px;
+$padding-between-elements: 10px;
+$border-radius: 10px;
 
 .popup-fixed {
   position: fixed;
@@ -11,32 +19,95 @@
   display: none;
 }
 
+.leaflet-popup-content {
+  margin: 0;
+}
+
 .leaflet-popup-content-wrapper {
-  width: 330px;
-  border-radius: 10px;
+  width: 270px;
+  padding: 0;
+  padding-right: 1px;
+
   float: right;
   position: fixed;
   right: 11px;
-  top: 75px;
+  top: 100px;
+
+  border-radius: $border-radius;
 }
 
 .scorecard-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding-top: $outer-padding;
+  padding-bottom: $padding-between-elements;
+  padding-left: $outer-padding;
+  padding-right: $outer-padding;
 }
 
 .scorecard-title {
   flex: 1;
   color: colors.$teal;
   font-weight: bold;
-  font-size: typography.$font-size-md;
+  font-size: typography.$font-size-xl;
+  line-height: 1.1;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.scorecard-accordion-toggle {
+  height: touchable-icons.$min-touch-target;
+  width: 100%;
+  padding: 0;
+  margin-top: $padding-between-elements;
+
+  font-size: typography.$font-size-base;
+  cursor: pointer;
+  text-align: left;
+  padding-left: $outer-padding;
+  padding-right: 0;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  background-color: colors.$white;
+  border-left: 0;
+  border-right: 0;
+  border-top: 1px solid colors.$gray-light-translucent;
+  border-bottom: 0;
+  border-bottom-left-radius: $border-radius;
+  border-bottom-right-radius: $border-radius;
+
+  .scorecard-accordion-title {
+    flex: 1;
+  }
+
+  .scorecard-accordion-icon-container {
+    height: touchable-icons.$min-touch-target;
+    width: touchable-icons.$min-touch-target;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    svg {
+      height: touchable-icons.$icon-size-sm;
+    }
+  }
+}
+
+.scorecard-accordion-content {
+  border-top: 1px solid colors.$gray-light-translucent;
+  padding-top: $padding-between-elements;
 }
 
 .leaflet-popup-content-wrapper p {
   font-size: typography.$font-size-base;
   color: colors.$black;
   margin: 0;
+  padding-left: $outer-padding;
+  padding-right: $outer-padding;
 }
 
 .share-icon-container {
@@ -44,18 +115,22 @@
 
   svg {
     color: colors.$teal !important;
+    font-size: typography.$font-size-lg;
+    padding-bottom: 2px;
   }
 }
 
 .popup-button a {
-  background-color: colors.$teal;
+  display: inline-block;
   padding: 10px;
+  margin: $padding-between-elements;
+
+  background-color: colors.$teal;
   font-size: typography.$font-size-base;
   color: colors.$white;
   border-radius: 8px;
   text-decoration: none;
   border: 1px solid colors.$teal;
-  display: inline-block;
 
   &:hover {
     background-color: colors.$white;
@@ -67,24 +142,4 @@
 .community-tag {
   font-size: typography.$font-size-sm;
   color: colors.$gray;
-}
-
-@media only screen and (max-width: 830px) {
-  .leaflet-popup-content-wrapper {
-    overflow-y: scroll;
-    overflow-x: hidden;
-    height: 119px;
-    float: left;
-    position: fixed;
-    bottom: 32px;
-    top: auto;
-    right: 10px;
-  }
-}
-
-@media only screen and (max-width: 480px) {
-  .leaflet-popup-content-wrapper {
-    width: 280px;
-    bottom: 40px;
-  }
 }

--- a/src/js/fontAwesome.ts
+++ b/src/js/fontAwesome.ts
@@ -1,5 +1,7 @@
 import { library, dom } from "@fortawesome/fontawesome-svg-core";
 import {
+  faChevronDown,
+  faChevronUp,
   faCircleInfo,
   faCircleXmark,
   faLink,
@@ -11,6 +13,8 @@ import "@fortawesome/fontawesome-svg-core/styles.css";
 
 const setUpIcons = (): void => {
   library.add(
+    faChevronDown,
+    faChevronUp,
     faCircleInfo,
     faCircleXmark,
     faLink,

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -67,7 +67,7 @@ const setScorecard = (cityId: CityId, cityProperties: ScoreCard): void => {
   setUpShareUrlClickListener(cityId);
 };
 
-const setScorecardAccordionListener = () => {
+const setUpScorecardAccordionListener = () => {
   // The event listener is on `map` because it is never erased, unlike the scorecard
   // being recreated every time the map moves. This is called "event delegation".
   const map = document.querySelector("#map");
@@ -102,4 +102,4 @@ const setScorecardAccordionListener = () => {
   });
 };
 
-export { setScorecard, setScorecardAccordionListener };
+export { setScorecard, setUpScorecardAccordionListener };

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -39,14 +39,14 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
   }
 
   const accordion = `<div class="scorecard-accordion">
-      <button class="scorecard-accordion-toggle">
+      <button class="scorecard-accordion-toggle" aria-expanded="false" aria-controls="scorecard-accordion-content">
         <span class="scorecard-accordion-title">Additional details</span>
-        <div class="scorecard-accordion-icon-container">
+        <div class="scorecard-accordion-icon-container" aria-hidden="true">
           <i class="fa-solid fa-chevron-down" title="expand additional details"></i>
           <i class="fa-solid fa-chevron-up" title="collapse additional details" style="display: none"></i>
         </div>
       </button>
-      <div id="scorecard-accordion-content" class="scorecard-accordion-content" style="display: none">
+      <div id="scorecard-accordion-content" class="scorecard-accordion-content" hidden>
         ${accordionLines.join("\n")}
       </div>
     </div>
@@ -67,24 +67,6 @@ const setScorecard = (cityId: CityId, cityProperties: ScoreCard): void => {
   setUpShareUrlClickListener(cityId);
 };
 
-const switchAccordionIcons = (
-  accordionToggle: HTMLButtonElement,
-  currentlyExpanded: boolean
-): void => {
-  const upIcon = accordionToggle.querySelector(".fa-chevron-up");
-  const downIcon = accordionToggle.querySelector(".fa-chevron-down");
-  if (!(upIcon instanceof SVGElement) || !(downIcon instanceof SVGElement))
-    return;
-
-  if (currentlyExpanded) {
-    upIcon.style.display = "none";
-    downIcon.style.display = "block";
-  } else {
-    upIcon.style.display = "block";
-    downIcon.style.display = "none";
-  }
-};
-
 const setScorecardAccordionListener = () => {
   // The event listener is on `map` because it is never erased, unlike the scorecard
   // being recreated every time the map moves. This is called "event delegation".
@@ -95,15 +77,28 @@ const setScorecardAccordionListener = () => {
     if (!(clicked instanceof Element)) return;
     const accordionToggle = clicked.closest(".scorecard-accordion-toggle");
     if (!(accordionToggle instanceof HTMLButtonElement)) return;
-
     const accordionContent = document.querySelector(
       "#scorecard-accordion-content"
     );
     if (!(accordionContent instanceof HTMLDivElement)) return;
-    const currentlyExpanded = accordionContent.style.display !== "none";
+    const upIcon = accordionToggle.querySelector(".fa-chevron-up");
+    const downIcon = accordionToggle.querySelector(".fa-chevron-down");
+    if (!(upIcon instanceof SVGElement) || !(downIcon instanceof SVGElement))
+      return;
 
-    accordionContent.style.display = currentlyExpanded ? "none" : "block";
-    switchAccordionIcons(accordionToggle, currentlyExpanded);
+    const currentlyExpanded =
+      accordionToggle.getAttribute("aria-expanded") === "true";
+    if (currentlyExpanded) {
+      accordionToggle.setAttribute("aria-expanded", "false");
+      accordionContent.hidden = true;
+      upIcon.style.display = "none";
+      downIcon.style.display = "block";
+    } else {
+      accordionToggle.setAttribute("aria-expanded", "true");
+      accordionContent.hidden = false;
+      upIcon.style.display = "block";
+      downIcon.style.display = "none";
+    }
   });
 };
 

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -13,7 +13,7 @@ import { CityId, ScoreCard, ScoreCards } from "./types";
 import { extractCityIdFromUrl } from "./cityId";
 import setUpIcons from "./fontAwesome";
 import setUpAbout from "./about";
-import { setScorecard, setScorecardAccordionListener } from "./scorecard";
+import { setScorecard, setUpScorecardAccordionListener } from "./scorecard";
 import setUpDropdown, { DROPDOWN } from "./dropdown";
 import cityBoundaries from "~/data/city-boundaries.geojson";
 import scoreCardsDetails from "~/data/score-cards.json";
@@ -105,8 +105,8 @@ const snapToCity = (map: Map, layer: ImageOverlay): void => {
   const bounds = layer.getBounds();
   map.fitBounds(bounds);
   const centerPoint = map.latLngToContainerPoint(bounds.getCenter());
-  const translateY = -40;
-  const translatedCenterPoint = centerPoint.add([0, translateY]);
+  const translateYPx = -40;
+  const translatedCenterPoint = centerPoint.add([0, translateYPx]);
   const translatedCenter = map.containerPointToLatLng(translatedCenterPoint);
   map.setView(translatedCenter, map.getZoom());
 };
@@ -242,7 +242,7 @@ const setUpSite = async (): Promise<void> => {
   setUpAbout();
 
   const map = createMap();
-  setScorecardAccordionListener();
+  setUpScorecardAccordionListener();
   const parkingLayer = await setUpParkingLotsLayer(map);
   await setUpCitiesLayer(map, parkingLayer);
 

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -13,7 +13,7 @@ import { CityId, ScoreCard, ScoreCards } from "./types";
 import { extractCityIdFromUrl } from "./cityId";
 import setUpIcons from "./fontAwesome";
 import setUpAbout from "./about";
-import setScorecard from "./scorecard";
+import { setScorecard, setScorecardAccordionListener } from "./scorecard";
 import setUpDropdown, { DROPDOWN } from "./dropdown";
 import cityBoundaries from "~/data/city-boundaries.geojson";
 import scoreCardsDetails from "~/data/score-cards.json";
@@ -99,13 +99,16 @@ const loadParkingLot = async (
 };
 
 /**
- * Centers view to city.
- *
- * @param map: The Leaflet map instance.
- * @param layer: The Leaflet layer with the city boundaries to snap to.
+ * Centers view to city, but translated down to account for the top UI elements.
  */
 const snapToCity = (map: Map, layer: ImageOverlay): void => {
-  map.fitBounds(layer.getBounds());
+  const bounds = layer.getBounds();
+  map.fitBounds(bounds);
+  const centerPoint = map.latLngToContainerPoint(bounds.getCenter());
+  const translateY = -40;
+  const translatedCenterPoint = centerPoint.add([0, translateY]);
+  const translatedCenter = map.containerPointToLatLng(translatedCenterPoint);
+  map.setView(translatedCenter, map.getZoom());
 };
 
 /**
@@ -239,6 +242,7 @@ const setUpSite = async (): Promise<void> => {
   setUpAbout();
 
   const map = createMap();
+  setScorecardAccordionListener();
   const parkingLayer = await setUpParkingLotsLayer(map);
   await setUpCitiesLayer(map, parkingLayer);
 


### PR DESCRIPTION
We now use an accordion in the scorecard to hide the details shown on the initial page load. Motivations:

* Fix information hierarchy. Our most important information is a) the map itself, b) city name, then c) what % of parking. Much less important are details like parking score and population, albeit useful for some users. By showing all the details on the initial load, we were detracting from more important information.
* Remove bad scroll experience on mobile. The expanded scorecard is too tall on mobile to show without covering up the map, so we before were truncating the scorecard. But this results in a confusing experience where you have to scroll to see more details; the scroll wasn't obvious either.

<details><summary>before: mobile</summary>

<img width="376" alt="Screenshot 2024-07-06 at 5 55 09 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/9ad13915-07c4-49d9-a3b6-32aac3080ed2">
</details>

<details><summary>before: desktop</summary>
<img width="1114" alt="Screenshot 2024-07-06 at 5 53 00 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/1aea548b-3c32-46ec-b930-e9fb41b9d68f">
</details>

<details><summary>after: mobile - unexpanded</summary>

<img width="375" alt="Screenshot 2024-07-06 at 5 54 38 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/6e8130d6-6d7d-4fbb-9707-5ca2032f0c2d">
</details>

<details><summary>after: desktop - unexpanded</summary>

<img width="1108" alt="Screenshot 2024-07-06 at 5 52 09 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/0c995772-d6c3-4298-b67a-e7085f33f7c5">
</details>

<details><summary>after: mobile - expanded</summary>

<img width="372" alt="Screenshot 2024-07-06 at 5 56 19 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/b9125a22-3a5b-4b15-b367-8f77432d4e2d">
</details>

<details><summary>after: desktop - expanded</summary>

<img width="1114" alt="Screenshot 2024-07-06 at 5 57 05 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/6a72cb66-4164-4c68-810a-2adbbf5f3108">

</details>

This change allows us to always show the scorecard in the same location in the top right corner. That consistency is a better UI. 

To counteract the scorecard covering the top of the map, we now translate the map downwards 40 pixels.

A follow up PR will revamp the top header to further improve upon this new map layout.