### PR TITLE
Use font-awesome icon for external link

### DIFF
--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -118,6 +118,18 @@ $border-radius: 10px;
   }
 }
 
+.reforms-link {
+  &:hover {
+    // We disable underlining because the font awesome icon won't
+    // have underlining on hover, which looks weird.
+    text-decoration: none;
+  }
+
+  svg {
+    transform: rotate(-45deg);
+  }
+}
+
 .community-tag {
   font-size: typography.$font-size-sm;
   color: colors.$gray;

--- a/src/js/fontAwesome.ts
+++ b/src/js/fontAwesome.ts
@@ -1,5 +1,6 @@
 import { library, dom } from "@fortawesome/fontawesome-svg-core";
 import {
+  faArrowRight,
   faChevronDown,
   faChevronUp,
   faCircleInfo,
@@ -13,6 +14,7 @@ import "@fortawesome/fontawesome-svg-core/styles.css";
 
 const setUpIcons = (): void => {
   library.add(
+    faArrowRight,
     faChevronDown,
     faChevronUp,
     faCircleInfo,

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -28,7 +28,7 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
 
   let reformsLine = `Parking reforms ${entry.reforms}`;
   if (entry.url) {
-    reformsLine += ` (<a href="${entry.url}">details ↗</a>)`;
+    reformsLine += ` (<a class="reforms-link" title="view parking reform details" href="${entry.url}">details <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a>)`;
   }
   listEntries.push(reformsLine);
 

--- a/tests/app/setUpSite.test.ts
+++ b/tests/app/setUpSite.test.ts
@@ -86,7 +86,7 @@ test("correctly load the city score card", async ({ page }) => {
     `City type: ${albanyExpected.cityType}`,
     `${albanyExpected.population} residents - city proper`,
     `${albanyExpected.urbanizedAreaPopulation} residents - urban area`,
-    `Parking reforms ${albanyExpected.reforms} (details ↗)`,
+    `Parking reforms ${albanyExpected.reforms} (details )`,
   ]);
   expect(new Set(contentLines)).toEqual(expectedLines);
 });


### PR DESCRIPTION
On iOS, the up-right arrow was rendering as an emoji and it looked weird. By using font awesome, the styling will be consistent.