### PR TITLE
Better align colors to logo

### DIFF
--- a/src/css/_about.scss
+++ b/src/css/_about.scss
@@ -9,7 +9,7 @@ div.about-text-popup {
   z-index: 2001;
   background-color: colors.$white;
   font-size: 18px;
-  border: 1px solid colors.$gray-light-translucent;
+  border: 1px solid colors.$gray-translucent;
   display: none;
   left: 10%;
   height: 60%;
@@ -19,7 +19,7 @@ div.about-text-popup {
 }
 
 div.about-text-popup svg.fa-circle-xmark {
-  color: colors.$gray-light;
+  color: colors.$gray;
 }
 
 div.about-text-container {

--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -6,11 +6,11 @@
 $label-font-size: typography.$font-size-md;
 $zoom-controls-top-offset: calc(70px - header.$header-height);
 $outer-border-thickness: 2px;
-$option-divider: 1px solid colors.$gray-light-translucent;
+$option-divider: 1px solid colors.$gray-translucent;
 
 .leaflet-control-zoom.leaflet-bar,
 .leaflet-control-layers.leaflet-control {
-  border: $outer-border-thickness solid colors.$gray-light-translucent;
+  border: $outer-border-thickness solid colors.$gray-translucent;
   border-radius: 4px;
 }
 

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -17,7 +17,7 @@ header {
 
   padding: $header-y-padding 10px;
 
-  background-color: colors.$gray-light;
+  background-color: colors.$gray;
   border-bottom: $header-border-bottom-size solid colors.$teal;
 }
 
@@ -72,6 +72,7 @@ header {
 
 .choices__heading {
   font-size: typography.$font-size-sm;
+  color: colors.$gray;
   cursor: default;
 }
 

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -82,7 +82,7 @@ $border-radius: 10px;
   background-color: colors.$white;
   border-left: 0;
   border-right: 0;
-  border-top: 1px solid colors.$gray-light-translucent;
+  border-top: 1px solid colors.$gray-translucent;
   border-bottom: 0;
   border-bottom-left-radius: $border-radius;
   border-bottom-right-radius: $border-radius;
@@ -105,7 +105,7 @@ $border-radius: 10px;
 }
 
 .scorecard-accordion-content {
-  border-top: 1px solid colors.$gray-light-translucent;
+  border-top: 1px solid colors.$gray-translucent;
   padding-top: $padding-between-elements;
 
   ul {

--- a/src/css/theme/_colors.scss
+++ b/src/css/theme/_colors.scss
@@ -1,7 +1,5 @@
 $teal: hsl(173, 72%, 46%);
 $white: hsl(0, 0%, 100%);
-$gray: hsl(0, 0%, 23.53%);
-$gray-light: hsl(0, 0%, 30%);
-$gray-light-translucent: hsla(0, 0%, 73%, 0.7);
 $black: hsl(0, 0%, 0%);
-$black-translucent: hsla(0, 0%, 0%, 0.2);
+$gray: hsl(0, 0%, 25.88%); // Color comes from the logo
+$gray-translucent: hsla(0, 0%, 70%, 0.7);


### PR DESCRIPTION
Changes:

* Uses the exact color from the logo for the top header
* Removes unused `$black-translucent` and consolidates the two gray colors
* Renames `$gray-light-translucent` to `$gray-translucent`

I'm still not very happy with `$gray-translucent`, but I don't know how to fix it. It's used for outer borders of UI elements, so I don't feel I can fix it until figuring out the depth idea from Refactoring UI.

Before:
<img width="375" alt="Screenshot 2024-07-08 at 8 17 15 AM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/76369da9-2cd2-4391-bd0c-ea2c4f2db868">

After:
<img width="376" alt="Screenshot 2024-07-08 at 8 16 52 AM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/2e6c65ca-4021-4e4b-90a2-aab9eca5693f">

