### PR TITLE
Use less noisy icon for about

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,15 +81,15 @@
       ></select>
       <div class="header-icons">
         <div class="header-about-icon-container">
-          <i class="fa-solid fa-circle-info" title="About"></i>
+          <i class="fa-regular fa-circle-question" title="about the map"></i>
         </div>
         <a href="#" class="header-share-icon-container"
           ><i
-            class="share-link-icon fa-solid fa-link fa-lg"
+            class="share-link-icon fa-solid fa-link"
             title="copy link"
           ></i
           ><i
-            class="share-check-icon fa-solid fa-check fa-lg"
+            class="share-check-icon fa-solid fa-check"
             title="link successfully copied"
             style="display: none"
           ></i>
@@ -101,7 +101,7 @@
         >
           <i
             class="fa-solid fa-up-right-from-square"
-            title="View fullscreen"
+            title="view fullscreen"
           ></i>
         </a>
       </div>
@@ -111,8 +111,8 @@
       <div class="about-text-container">
         <div class="about-close">
           <i
-            class="close-icon fa-solid fa-circle-xmark"
-            title="Close fullscreen"
+            class="close-icon fa-regular fa-circle-xmark"
+            title="close about popup"
           ></i>
         </div>
         <h2>Parking Lot Coverage Map</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,9 @@
       "name": "parking-lot-map",
       "version": "1.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.4.0",
-        "@fortawesome/free-solid-svg-icons": "^6.4.0",
+        "@fortawesome/fontawesome-svg-core": "^6.5.2",
+        "@fortawesome/free-regular-svg-icons": "^6.5.2",
+        "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@parcel/resolver-glob": "^2.10.3",
         "choices.js": "^10.2.0",
         "leaflet": "~1.9.3",
@@ -307,33 +308,45 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
-      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+      "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
-      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
+      "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.5.1"
+        "@fortawesome/fontawesome-common-types": "6.5.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.2.tgz",
+      "integrity": "sha512-iabw/f5f8Uy2nTRtJ13XZTS1O5+t+anvlamJ3zJGLEVE2pKsAWhPv2lq01uQlfgCX7VaveT3EVs515cCN9jRbw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.2"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
-      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
+      "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.5.1"
+        "@fortawesome/fontawesome-common-types": "6.5.2"
       },
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "test-dist": "PORT=8080 playwright test"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.4.0",
-    "@fortawesome/free-solid-svg-icons": "^6.4.0",
+    "@fortawesome/fontawesome-svg-core": "^6.5.2",
+    "@fortawesome/free-solid-svg-icons": "^6.5.2",
+    "@fortawesome/free-regular-svg-icons": "^6.5.2",
     "@parcel/resolver-glob": "^2.10.3",
     "choices.js": "^10.2.0",
     "leaflet": "~1.9.3",

--- a/src/js/fontAwesome.ts
+++ b/src/js/fontAwesome.ts
@@ -1,10 +1,9 @@
 import { library, dom } from "@fortawesome/fontawesome-svg-core";
+import { faCircleQuestion, faCircleXmark } from "@fortawesome/free-regular-svg-icons";
 import {
   faArrowRight,
   faChevronDown,
   faChevronUp,
-  faCircleInfo,
-  faCircleXmark,
   faLink,
   faUpRightFromSquare,
   faCheck,
@@ -17,8 +16,8 @@ const setUpIcons = (): void => {
     faArrowRight,
     faChevronDown,
     faChevronUp,
-    faCircleInfo,
     faCircleXmark,
+    faCircleQuestion,
     faLink,
     faUpRightFromSquare,
     faCheck,


### PR DESCRIPTION
This is a recommendation from Refactoring UI. The original icon for "about" was before much more visually dominating than the two other icons. It recommends trying to keep like elements with a similar visual weight.

Before:

<img width="375" alt="Screenshot 2024-07-08 at 8 41 06 AM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/f8bf4b5c-d3ab-4246-bac3-90e38e5918c3">

After: 

<img width="377" alt="Screenshot 2024-07-08 at 8 40 53 AM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/b1e7db95-d6bc-458a-9255-4ceab03231a9">
