### PR TITLE
Fix spacing on mobile iframe

### DIFF
--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -42,6 +42,16 @@ header {
     height: touchable-icons.$icon-size-md;
     width: touchable-icons.$icon-size-md;
   }
+
+  .header-link-icon-container {
+    // We don't show the icon on small screens because it takes up
+    // too much screen real estate, and it's not very useful to see
+    // the map in full-screen vs iframe if you're on such a small screen.
+    display: none;
+    @include breakpoints.gt-xs {
+      display: inline-flex;
+    }
+  }
 }
 
 .choices {

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -23,7 +23,11 @@ $border-radius: 10px;
 }
 
 .leaflet-popup-content-wrapper {
-  width: 270px;
+  width: 260px;
+  @include breakpoints.gt-xs {
+    width: 280px;
+  }
+
   padding: 0;
   padding-right: 1px;
 

--- a/src/css/theme/_breakpoints.scss
+++ b/src/css/theme/_breakpoints.scss
@@ -1,4 +1,7 @@
 // Inspired by https://dev.to/alberto/defining-responsive-breakpoints-made-easy-with-sass-mixins-26p0.
+//
+// When developing, check how 335px x 600px renders. This is what the map as an iframe
+// looks like on iPhone SE.
 
 $sm-width: "640px";
 $md-width: "768px";


### PR DESCRIPTION
The map looked great when going directly to the full screen site. But it's too big when embedded in `/resources/parking-lot-map` as an iframe.

This PR fixes that by:

* making scorecard narrower on small screens
* hiding the "view fullscreen" icon on mobile. It's not even very useful to do this on mobile because the fullscreen app is only a few pixels bigger than the iframe

<details><summary>before</summary>

<img width="322" alt="Screenshot 2024-07-08 at 6 25 43 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/7a5d6d7c-93e5-4dd6-8610-6bc8c7e2f0d3">
</details>

<details><summary>after</summary>

<img width="338" alt="Screenshot 2024-07-08 at 6 25 19 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/c24c712c-0cff-4429-ac7b-2d244a50d4d7">
</details>