### PR TITLE
Define `xxs` breakpoint

### DIFF
--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -48,7 +48,7 @@ header {
     // too much screen real estate, and it's not very useful to see
     // the map in full-screen vs iframe if you're on such a small screen.
     display: none;
-    @include breakpoints.gt-xs {
+    @include breakpoints.gt-xxs {
       display: inline-flex;
     }
   }

--- a/src/css/_logo.scss
+++ b/src/css/_logo.scss
@@ -12,7 +12,7 @@
   @include breakpoints.gt-xs {
     bottom: 20px;
   }
-  @include breakpoints.gt-md {
+  @include breakpoints.gt-sm {
     bottom: 10px;
   }
 

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -24,7 +24,7 @@ $border-radius: 10px;
 
 .leaflet-popup-content-wrapper {
   width: 260px;
-  @include breakpoints.gt-xs {
+  @include breakpoints.gt-xxs {
     width: 280px;
   }
 

--- a/src/css/theme/_breakpoints.scss
+++ b/src/css/theme/_breakpoints.scss
@@ -3,10 +3,17 @@
 // When developing, check how 335px x 600px renders. This is what the map as an iframe
 // looks like on iPhone SE.
 
+$xs-width: "480px";
 $sm-width: "640px";
 $md-width: "768px";
 $lg-width: "1024px";
 $xl-width: "1280px";
+
+@mixin gt-xxs() {
+  @media screen and (min-width: $xs-width) {
+    @content();
+  }
+}
 
 @mixin gt-xs() {
   @media screen and (min-width: $sm-width) {


### PR DESCRIPTION
Due to the iframe, it's common for us on desktop to have a small render of the map, but still much wider than mobile. https://github.com/ParkingReformNetwork/parking-lot-map/pull/216 was overly aggressive in hiding the fullscreen icon in that case; there, the full-screen icon is actually quite useful.

This defines a new smaller breakpoint and adjusts some responsive styling to be bigger on small, but not xsmall, screens.