### PR TITLE
Improve styling of attribution

### DIFF
--- a/src/css/_attribution.scss
+++ b/src/css/_attribution.scss
@@ -3,11 +3,11 @@
 @use "theme/typography";
 
 .leaflet-container .leaflet-control-attribution {
-    font-size: typography.$font-size-xs;
-    background-color: colors.$white;
-    border-top-left-radius: 2px;
+  font-size: typography.$font-size-xs;
+  background-color: colors.$white;
+  border-top-left-radius: 2px;
 
-    @include breakpoints.gt-sm {
-        font-size: typography.$font-size-sm;
-    }
+  @include breakpoints.gt-sm {
+    font-size: typography.$font-size-sm;
+  }
 }

--- a/src/css/_attribution.scss
+++ b/src/css/_attribution.scss
@@ -1,0 +1,13 @@
+@use "theme/breakpoints";
+@use "theme/colors";
+@use "theme/typography";
+
+.leaflet-container .leaflet-control-attribution {
+    font-size: typography.$font-size-xs;
+    background-color: colors.$white;
+    border-top-left-radius: 2px;
+
+    @include breakpoints.gt-sm {
+        font-size: typography.$font-size-sm;
+    }
+}

--- a/src/css/_logo.scss
+++ b/src/css/_logo.scss
@@ -12,7 +12,7 @@
   @include breakpoints.gt-xs {
     bottom: 20px;
   }
-  @include breakpoints.gt-sm {
+  @include breakpoints.gt-md {
     bottom: 10px;
   }
 

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -1,4 +1,5 @@
 @use "about";
+@use "attribution";
 @use "controls";
 @use "logo";
 @use "header";


### PR DESCRIPTION
* Makes the font bigger on > small screens
* Uses a non-transparent background, which is more clear on our high-contrast map layer.

Before:

<img width="592" alt="Screenshot 2024-07-08 at 7 48 20 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/b150275f-cb50-42b8-9c6e-b094f09d359d">

After:
<img width="684" alt="Screenshot 2024-07-08 at 7 47 47 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/209e3e86-ae78-4545-9930-eb114e685cca">
