### PR TITLE
Hide full-screen icon when not an iframe

### DIFF
--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -47,6 +47,8 @@ header {
     // We don't show the icon on small screens because it takes up
     // too much screen real estate, and it's not very useful to see
     // the map in full-screen vs iframe if you're on such a small screen.
+    //
+    // iframe.ts also disables the icon when the site is not in an iframe.
     display: none;
     @include breakpoints.gt-xxs {
       display: inline-flex;

--- a/src/js/iframe.ts
+++ b/src/js/iframe.ts
@@ -1,0 +1,25 @@
+/* global document, window */
+
+const isIFrame = (): boolean => {
+  try {
+    return window.self !== window.top;
+  } catch (e) {
+    return false;
+  }
+};
+
+/** If the site is not inside an iframe, disable the full-screen icon
+ * because it's redundant.
+ *
+ * Note that _header.scss also disables the icon on mobile.
+ */
+const maybeDisableFullScreenIcon = (): void => {
+  if (isIFrame()) return;
+  const iconContainer = document.querySelector(
+    ".header-full-screen-icon-container"
+  );
+  if (!(iconContainer instanceof HTMLAnchorElement)) return;
+  iconContainer.style.display = "none";
+};
+
+export default maybeDisableFullScreenIcon;

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -9,13 +9,16 @@ import {
 } from "leaflet";
 import { Feature, GeoJsonProperties, Geometry } from "geojson";
 import "leaflet/dist/leaflet.css";
+
 import { CityId, ScoreCard, ScoreCards } from "./types";
 import { extractCityIdFromUrl } from "./cityId";
 import setUpIcons from "./fontAwesome";
+import maybeDisableFullScreenIcon from "./iframe";
 import setUpAbout from "./about";
 import updateIconsShareLink from "./share";
 import { setScorecard, setUpScorecardAccordionListener } from "./scorecard";
 import setUpDropdown, { DROPDOWN } from "./dropdown";
+
 import cityBoundaries from "~/data/city-boundaries.geojson";
 import scoreCardsDetails from "~/data/score-cards.json";
 
@@ -240,6 +243,7 @@ const setUpParkingLotsLayer = async (
 
 const setUpSite = async (): Promise<void> => {
   setUpIcons();
+  maybeDisableFullScreenIcon();
 
   const initialCityId = extractCityIdFromUrl(window.location.href);
   setUpDropdown(initialCityId, "atlanta-ga");


### PR DESCRIPTION
The button does nothing when you're already at https://parkingreform.org/parking-lot-map. It's only useful when you're inside an iframe.