### PR TITLE
Add back community contribution disclaimer

### DIFF
--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -4,9 +4,13 @@
 @use "header";
 
 $label-font-size: typography.$font-size-md;
-$zoom-controls-top-offset: calc(70px - header.$header-height);
+$zoom-controls-top-offset: calc(64px - header.$header-height);
 $outer-border-thickness: 2px;
 $option-divider: 1px solid colors.$gray-translucent;
+
+.leaflet-left .leaflet-control {
+  margin-left: 8px;
+}
 
 .leaflet-control-zoom.leaflet-bar,
 .leaflet-control-layers.leaflet-control {
@@ -47,7 +51,7 @@ $option-divider: 1px solid colors.$gray-translucent;
     $zoom-controls-top-offset + $zoom-controls-height +
       $margin-between-zoom-control
   );
-  margin-left: 10px; // Mirrors zoom controls.
+  margin-left: 8px; // Mirrors zoom controls.
   right: auto;
 }
 

--- a/src/css/_logo.scss
+++ b/src/css/_logo.scss
@@ -3,7 +3,7 @@
 
 .prn-logo {
   position: absolute;
-  left: 10px;
+  left: 8px;
   z-index: 2001;
 
   // `bottom` is set so high to avoid covering the attribution

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -33,8 +33,8 @@ $border-radius: 10px;
 
   float: right;
   position: fixed;
-  right: 10px;
-  top: calc(header.$header-height + 12px);
+  right: 8px;
+  top: calc(header.$header-height + 6px);
 
   border-radius: $border-radius;
   color: colors.$black;
@@ -134,7 +134,12 @@ $border-radius: 10px;
   }
 }
 
-.community-tag {
+.community-contribution-warning {
   font-size: typography.$font-size-sm;
   color: colors.$gray;
+  margin-top: $padding-between-elements;
+  margin-bottom: $padding-between-elements;
+  margin-left: $outer-padding;
+  margin-right: $outer-padding;
+  overflow-wrap: break-word;
 }

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -2,18 +2,14 @@ import { Popup } from "leaflet";
 import { ScoreCard, ScoreCardDetails } from "./types";
 
 const generateScorecard = (entry: ScoreCardDetails): string => {
-  const header = `
+  let header = `
       <h1 class="scorecard-title">Parking lots in ${entry.name}</h1>
       <p>${entry.percentage} of the central city is off-street parking</p>
       `;
 
-  // TODO: figure out design for contributions
-  // if ("contribution" in entry) {
-  // accordionLines.push("<hr>");
-  // accordionLines.push(
-  //   `<div><span class="community-tag"><i class="fa-solid fa-triangle-exclamation"></i> Community-maintained map. <br>Email ${entry.contribution} for issues.</span></div>`
-  // );
-  // }
+  if ("contribution" in entry) {
+    header += `<div class="community-contribution-warning"><i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i> This city is maintained by <a href="mailto:${entry.contribution}">${entry.contribution}</a></div>`;
+  }
 
   const listEntries = [];
   if (entry.parkingScore) {

--- a/tests/app/communityMaps.test.ts
+++ b/tests/app/communityMaps.test.ts
@@ -3,8 +3,7 @@ import { expect, test } from "@playwright/test";
 test("there are exactly 103 official city maps", async ({ page }) => {
   await page.goto("/");
   await page.waitForSelector(".choices");
-  const choices = await page.locator(".choices");
-  await choices.click();
+  await page.locator(".choices").click();
   await page.waitForSelector(".is-active");
 
   const toggleValues = await page.$eval(


### PR DESCRIPTION
It's important that the disclaimer always shows, such as screenshots. It's unfortunate that this disclaimer takes up valuable vertical space on mobile, but I couldn't think of any ways to minimize the impact:

* Can't use 12px font-size without violating accessibility. Already at 14px.
* We could reduce the padding in the scorecarad, but it's already quite tight
* I couldn't think of shorter copy because it's important that we have the email address 

This PR does reduce margins for the map controls to regain some space.

<img width="338" alt="Screenshot 2024-07-09 at 6 47 32 AM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/eb2b0f8f-9262-4e15-850f-045c3db7ec1f">
