### PR TITLE
Make contributor warning more concise

### DIFF
--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -141,5 +141,4 @@ $border-radius: 10px;
   margin-bottom: $padding-between-elements;
   margin-left: $outer-padding;
   margin-right: $outer-padding;
-  overflow-wrap: break-word;
 }

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -8,7 +8,10 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
       `;
 
   if ("contribution" in entry) {
-    header += `<div class="community-contribution-warning"><i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i> This city is maintained by <a href="mailto:${entry.contribution}">${entry.contribution}</a></div>`;
+    header += `<div class="community-contribution-warning">
+      <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i> 
+      <a href="mailto:${entry.contribution}" title="email map maintainer: ${entry.contribution}">Community-maintained</a> map
+    </div>`;
   }
 
   const listEntries = [];


### PR DESCRIPTION
I realized that it's not critical that we show the email address in the scorecard at all times. What we really care about is making sure that no ever misattributes a data error to PRN. Less important is knowing who is responsible, as long as they have a way to discover it.

So, we now limit the text to only one line, which restores valuable real estate. We share the email address by using an `<a>` with `mailto:` and also the `title` set to describe who the maintainer is.

I also considered instead having some type of hover/click interaction with a tooltip saying who the maintainer is. However, tooltips are hard to implement on mobile since it doesn't have hover, only clicking. So I went with this simpler implementation as "good enough".

<img width="339" alt="Screenshot 2024-07-09 at 7 14 38 AM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/84c3bee5-40ad-4892-a50e-f2536650f0dc">
