### PR TITLE
Tweak contributor disclaimer

### DIFF
--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -34,7 +34,7 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
 
   if ("contribution" in entry) {
     listEntries.push(
-      `<a href="mailto:${entry.contribution}" title="email ${entry.contribution}">Contact data maintainer</a>`
+      `<a href="mailto:${entry.contribution}">Email data maintainer</a>`
     );
   }
 

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -10,7 +10,7 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
   if ("contribution" in entry) {
     header += `<div class="community-contribution-warning">
       <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i> 
-      <a href="mailto:${entry.contribution}" title="email map maintainer: ${entry.contribution}">Community-maintained</a> map
+      Community-maintained map
     </div>`;
   }
 
@@ -31,6 +31,12 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
     reformsLine += ` (<a class="reforms-link" title="view parking reform details" href="${entry.url}">details <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a>)`;
   }
   listEntries.push(reformsLine);
+
+  if ("contribution" in entry) {
+    listEntries.push(
+      `<a href="mailto:${entry.contribution}" title="email ${entry.contribution}">Contact data maintainer</a>`
+    );
+  }
 
   const accordion = `<div class="scorecard-accordion">
       <button


### PR DESCRIPTION
Tung pointed out it was confusing to link the "Community-maintained" text in the disclaimer because people thought it would link to more info about that program, not the email of the maintainer.

Instead, Tung had the idea of putting the email address in the Additional details.

This alternative is great because it keeps the disclaimer at one line, which we need to not cover the map on mobile.

<img width="279" alt="Screenshot 2024-07-09 at 9 33 46 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/7a1677f3-ecf6-4854-84d0-902387001e00">

<img width="282" alt="Screenshot 2024-07-09 at 9 48 19 PM" src="https://github.com/ParkingReformNetwork/parking-lot-map/assets/14852634/b35d4930-4c05-4e11-9269-80694d805beb">

