### PR TITLE
Align borders

### DIFF
--- a/src/css/_about.scss
+++ b/src/css/_about.scss
@@ -1,3 +1,4 @@
+@use "theme/borders";
 @use "theme/breakpoints";
 @use "theme/colors";
 @use "theme/icons";
@@ -28,8 +29,8 @@
   font-size: typography.$font-size-base;
   padding: spacing.$container-edge-spacing;
 
-  border: 1px solid colors.$gray-translucent;
-  border-radius: 10px;
+  border: borders.$component-border;
+  border-radius: borders.$border-radius;
 
   overflow-y: auto;
 

--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -1,3 +1,4 @@
+@use "theme/borders";
 @use "theme/colors";
 @use "theme/spacing";
 @use "theme/typography";
@@ -7,17 +8,15 @@ $label-font-size: typography.$font-size-md;
 $zoom-controls-top-offset: calc(
   58px + spacing.$map-controls-margin-top - header.$header-height
 );
-$outer-border-thickness: 2px;
-$option-divider: 1px solid colors.$gray-translucent;
 
 .leaflet-left .leaflet-control {
   margin-left: spacing.$map-controls-margin-x;
 }
 
-.leaflet-control-zoom.leaflet-bar,
+.leaflet-control-zoom.leaflet-bar.leaflet-control,
 .leaflet-control-layers.leaflet-control {
-  border: $outer-border-thickness solid colors.$gray-translucent;
-  border-radius: 4px;
+  border: borders.$component-border;
+  border-radius: borders.$border-radius;
 }
 
 .leaflet-control-zoom.leaflet-bar {
@@ -34,7 +33,14 @@ $option-divider: 1px solid colors.$gray-translucent;
     justify-content: center;
 
     &:first-child {
-      border-bottom: $option-divider;
+      border-bottom: borders.$component-inner-divider;
+      border-top-left-radius: borders.$border-radius;
+      border-top-right-radius: borders.$border-radius;
+    }
+
+    &:last-child {
+      border-bottom-left-radius: borders.$border-radius;
+      border-bottom-right-radius: borders.$border-radius;
     }
   }
 }
@@ -46,7 +52,7 @@ $option-divider: 1px solid colors.$gray-translucent;
 
 #map > div.leaflet-control-container > div.leaflet-top.leaflet-right {
   $zoom-controls-height: calc(
-    (spacing.$min-touch-target * 2) + $outer-border-thickness
+    (spacing.$min-touch-target * 2) + borders.$border-thickness
   );
   top: calc(
     $zoom-controls-top-offset + $zoom-controls-height + spacing.$element-gap
@@ -68,7 +74,7 @@ $option-divider: 1px solid colors.$gray-translucent;
   line-height: 1;
 
   &:first-child {
-    border-bottom: $option-divider;
+    border-bottom: borders.$component-inner-divider;
   }
 
   display: flex;

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -1,3 +1,4 @@
+@use "theme/borders";
 @use "theme/breakpoints";
 @use "theme/colors";
 @use "theme/spacing";
@@ -64,7 +65,6 @@ $header-height: calc(
 
 .choices[data-type*="select-one"] {
   .choices__inner {
-    border-radius: 10px;
     color: colors.$black;
     font-size: typography.$font-size-base;
     line-height: 1.2; // To vertically center the text.
@@ -74,6 +74,18 @@ $header-height: calc(
     min-width: 220px;
     @include breakpoints.gt-xs {
       min-width: 300px;
+    }
+
+    border-top-left-radius: borders.$border-radius;
+    border-top-right-radius: borders.$border-radius;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  &:not(.is-open) {
+    .choices__inner {
+      border-bottom-left-radius: borders.$border-radius;
+      border-bottom-right-radius: borders.$border-radius;
     }
   }
 

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -1,11 +1,10 @@
+@use "theme/borders";
 @use "theme/breakpoints";
 @use "theme/colors";
 @use "theme/spacing";
 @use "theme/icons";
 @use "theme/typography";
 @use "header";
-
-$border-radius: 10px;
 
 .popup-fixed {
   position: fixed;
@@ -35,7 +34,9 @@ $border-radius: 10px;
   right: spacing.$map-controls-margin-x;
   top: calc(header.$header-height + spacing.$map-controls-margin-top);
 
-  border-radius: $border-radius;
+  border: borders.$component-border;
+  border-radius: borders.$border-radius;
+  box-shadow: none;
   color: colors.$black;
 
   p,
@@ -85,10 +86,10 @@ $border-radius: 10px;
   background-color: colors.$white;
   border-left: 0;
   border-right: 0;
-  border-top: 1px solid colors.$gray-translucent;
+  border-top: borders.$component-inner-divider;
   border-bottom: 0;
-  border-bottom-left-radius: $border-radius;
-  border-bottom-right-radius: $border-radius;
+  border-bottom-left-radius: borders.$border-radius;
+  border-bottom-right-radius: borders.$border-radius;
 
   .scorecard-accordion-title {
     flex: 1;
@@ -108,7 +109,7 @@ $border-radius: 10px;
 }
 
 .scorecard-accordion-content {
-  border-top: 1px solid colors.$gray-translucent;
+  border-top: borders.$component-inner-divider;
   padding-top: spacing.$element-gap;
 
   ul {

--- a/src/css/theme/_borders.scss
+++ b/src/css/theme/_borders.scss
@@ -1,0 +1,7 @@
+@use "colors";
+
+$border-radius: 5px;
+
+$border-thickness: 1px;
+$component-border: $border-thickness solid colors.$black-translucent;
+$component-inner-divider: $border-thickness solid colors.$black-translucent;

--- a/src/css/theme/_colors.scss
+++ b/src/css/theme/_colors.scss
@@ -2,4 +2,4 @@ $teal: hsl(173, 72%, 46%);
 $white: hsl(0, 0%, 100%);
 $black: hsl(0, 0%, 0%);
 $gray: hsl(0, 0%, 25.88%); // Color comes from the logo
-$gray-translucent: hsla(0, 0%, 70%, 0.7);
+$black-translucent: hsla(0, 0%, 0%, 0.4);


### PR DESCRIPTION
Uses a consistent style of 1px borders with `hsla(0, 0%, 0%, 0.4)`, and removes box shadows. 

I played around with box shadows, but it was too hard to get something that consistently looked good. A flat design is simpler.

Before:

<img width="378" alt="Screenshot 2024-07-14 at 5 07 42 PM" src="https://github.com/user-attachments/assets/e788984d-e25e-4eca-8a45-dab9629031b5">

After:

<img width="375" alt="Screenshot 2024-07-14 at 5 07 20 PM" src="https://github.com/user-attachments/assets/eae5878b-5762-41ad-9129-04be816c3aaa">
