### PR TITLE
Add border around attribution

### DIFF
--- a/src/css/_attribution.scss
+++ b/src/css/_attribution.scss
@@ -1,3 +1,4 @@
+@use "theme/borders";
 @use "theme/breakpoints";
 @use "theme/colors";
 @use "theme/typography";
@@ -5,7 +6,12 @@
 .leaflet-container .leaflet-control-attribution {
   font-size: typography.$font-size-xs;
   background-color: colors.$white;
-  border-top-left-radius: 2px;
+  border-top: borders.$component-border;
+
+  @include breakpoints.gt-xs {
+    border-top-left-radius: borders.$border-radius;
+    border-left: borders.$component-border;
+  }
 
   @include breakpoints.gt-sm {
     font-size: typography.$font-size-sm;


### PR DESCRIPTION
This makes the style consistent so that there is better contrast against the white map. 

<img width="763" alt="Screenshot 2024-07-17 at 7 42 25 PM" src="https://github.com/user-attachments/assets/8b05967e-465f-42dd-bf56-d47767c90655">

On mobile, we don't have a left border:

<img width="381" alt="Screenshot 2024-07-17 at 7 42 36 PM" src="https://github.com/user-attachments/assets/e260de00-f0f6-4ddc-a69b-8369f46d72b1">
