### PR TITLE
Hide zoom controls on touch devices

### DIFF
--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -1,5 +1,6 @@
 @use "theme/borders";
 @use "theme/colors";
+@use "theme/input-mode";
 @use "theme/spacing";
 @use "theme/typography";
 @use "header";
@@ -21,6 +22,10 @@ $zoom-controls-top-offset: calc(
 
 .leaflet-control-zoom.leaflet-bar {
   top: $zoom-controls-top-offset;
+
+  @include input-mode.touch-exclusive {
+    display: none;
+  }
 
   a {
     width: spacing.$min-touch-target;
@@ -57,6 +62,11 @@ $zoom-controls-top-offset: calc(
   top: calc(
     $zoom-controls-top-offset + $zoom-controls-height + spacing.$element-gap
   );
+
+  @include input-mode.touch-exclusive {
+    top: $zoom-controls-top-offset;
+  }
+
   margin-left: spacing.$map-controls-margin-x;
   right: auto;
 }

--- a/src/css/theme/_input-mode.scss
+++ b/src/css/theme/_input-mode.scss
@@ -1,0 +1,5 @@
+@mixin touch-exclusive() {
+  @media (hover: none) and (pointer: coarse) {
+    @content();
+  }
+}


### PR DESCRIPTION
The idea is that zoom controls are redundant on touch devices because you can pinch to zoom in and out.

However, https://ux.stackexchange.com/questions/125489/do-people-actually-use-the-zoom-buttons-on-a-map has some good points that it is more accessible to keep the buttons, including for one-handed users who cannot pinch.

<img width="336" alt="Screenshot 2024-07-18 at 10 52 13 PM" src="https://github.com/user-attachments/assets/fe804060-4f42-4fd6-9c73-3dbd3aaa02ae">
