### PR TITLE
Hide "select" text in search component

### DIFF
--- a/src/css/_dropdown.scss
+++ b/src/css/_dropdown.scss
@@ -1,0 +1,61 @@
+@use "theme/borders";
+@use "theme/colors";
+@use "theme/spacing";
+@use "theme/typography";
+
+.choices {
+  margin-bottom: 0;
+}
+
+.choices[data-type*="select-one"] {
+  .choices__inner {
+    color: colors.$black;
+    font-size: typography.$font-size-base;
+    line-height: 1.2; // To vertically center the text.
+
+    height: spacing.$min-touch-target;
+    width: 220px;
+
+    border-top-left-radius: borders.$border-radius;
+    border-top-right-radius: borders.$border-radius;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  &:not(.is-open) {
+    .choices__inner {
+      border-bottom-left-radius: borders.$border-radius;
+      border-bottom-right-radius: borders.$border-radius;
+    }
+  }
+
+  .choices__input {
+    // Cannot be less than 16px due to iOS autozoom:
+    //   https://weblog.west-wind.com/posts/2023/Apr/17/Preventing-iOS-Safari-Textbox-Zooming
+    font-size: typography.$font-size-base;
+  }
+}
+
+.choices__heading {
+  font-size: typography.$font-size-sm;
+  color: colors.$gray;
+  cursor: default;
+}
+
+div.choices__item.choices__item--choice.choices__item--selectable {
+  font-size: typography.$font-size-base;
+  height: spacing.$min-touch-target;
+}
+
+.choices__list--dropdown,
+.choices__list[aria-expanded] {
+  z-index: 1001;
+  color: colors.$black;
+}
+
+.choices__list--dropdown .choices__item--selectable,
+.choices__list[aria-expanded] .choices__item--selectable {
+  // Choices.js sets this to 100px to account for itemSelectText. But we disable that,
+  // so we want to use the normal padding it would otherwise use of 10px.
+  padding-right: 10px;
+}

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -3,7 +3,6 @@
 @use "theme/colors";
 @use "theme/spacing";
 @use "theme/icons";
-@use "theme/typography";
 
 // We don't use $container-edge-spacing to save vertical space.
 $header-y-padding: spacing.$element-gap;
@@ -55,58 +54,4 @@ $header-height: calc(
   @include breakpoints.gt-xxs {
     display: inline-flex;
   }
-}
-
-.choices {
-  margin-bottom: 0;
-}
-
-.choices[data-type*="select-one"] {
-  .choices__inner {
-    color: colors.$black;
-    font-size: typography.$font-size-base;
-    line-height: 1.2; // To vertically center the text.
-
-    height: spacing.$min-touch-target;
-
-    min-width: 220px;
-    @include breakpoints.gt-xs {
-      min-width: 300px;
-    }
-
-    border-top-left-radius: borders.$border-radius;
-    border-top-right-radius: borders.$border-radius;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  &:not(.is-open) {
-    .choices__inner {
-      border-bottom-left-radius: borders.$border-radius;
-      border-bottom-right-radius: borders.$border-radius;
-    }
-  }
-
-  .choices__input {
-    // Cannot be less than 16px due to iOS autozoom:
-    //   https://weblog.west-wind.com/posts/2023/Apr/17/Preventing-iOS-Safari-Textbox-Zooming
-    font-size: typography.$font-size-base;
-  }
-}
-
-.choices__heading {
-  font-size: typography.$font-size-sm;
-  color: colors.$gray;
-  cursor: default;
-}
-
-div.choices__item.choices__item--choice.choices__item--selectable {
-  font-size: typography.$font-size-base;
-  height: spacing.$min-touch-target;
-}
-
-.choices__list--dropdown,
-.choices__list[aria-expanded] {
-  z-index: 1001;
-  color: colors.$black;
 }

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -5,6 +5,7 @@
 @use "about";
 @use "attribution";
 @use "controls";
+@use "dropdown";
 @use "header";
 @use "logo";
 @use "map";

--- a/src/js/dropdown.ts
+++ b/src/js/dropdown.ts
@@ -5,9 +5,13 @@ import { CityId, ScoreCardDetails, dropdownChoice } from "./types";
 
 export const DROPDOWN = new Choices("#city-dropdown", {
   allowHTML: false,
-  itemSelectText: "Select",
+  itemSelectText: "",
   searchEnabled: true,
-  shouldSort: false, // since cities are already alphabetical order in scorecard, disabling this option allows us to show PRN maps at the top.
+  searchResultLimit: 6,
+  searchFields: ["label"],
+  // Since cities are already alphabetical order in scorecard,
+  // disabling this option allows us to show PRN maps at the top.
+  shouldSort: false,
 });
 
 const setUpDropdown = (initialCityId: CityId, fallBackCityId: CityId) => {


### PR DESCRIPTION
On large screens, choices.js has a little "select" label to the right of every entry. But there is no good reason for that. The UI is obvious already.

Fixing this allows us to keep the search/select a consistent 220px regardless of mobile vs desktop, meaning we cover less of the map.

Before:

<img width="305" alt="Screenshot 2024-07-21 at 8 45 43 AM" src="https://github.com/user-attachments/assets/fa67f325-2696-49e7-9371-45ba9453589a">

After:

<img width="226" alt="Screenshot 2024-07-21 at 8 45 02 AM" src="https://github.com/user-attachments/assets/ace17513-65dd-413a-99ef-795f5f707ace">
