### PR TITLE
Improve icon accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,39 +80,52 @@
         aria-label="select the city"
       ></select>
       <nav class="header-icons">
-        <div class="header-icon-container header-about-icon-container">
-          <i class="fa-regular fa-circle-question" title="about the map"></i>
-        </div>
-        <a class="header-icon-container header-share-icon-container"
-          ><i class="share-link-icon fa-solid fa-link" title="copy link"></i
+        <button
+          class="header-icon-container header-about-icon-container"
+          title="about the map"
+          aria-expanded="false"
+          aria-controls="about-popup"
+        >
+          <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
+          <span class="sr-only">toggle a popup describing the map</span>
+        </button>
+        <a
+          class="header-icon-container header-share-icon-container"
+          title="copy link"
+          ><i class="share-link-icon fa-solid fa-link" aria-hidden="true"></i
           ><i
             class="share-check-icon fa-solid fa-check"
-            title="link successfully copied"
             style="display: none"
+            aria-hidden="true"
           ></i>
         </a>
         <a
           class="header-icon-container header-full-screen-icon-container"
           href="https://parkingreform.org/parking-lot-map/"
+          title="view fullscreen"
           target="_blank"
         >
-          <i
-            class="fa-solid fa-up-right-from-square"
-            title="view fullscreen"
-          ></i>
+          <i class="fa-solid fa-up-right-from-square" aria-hidden="true"></i>
+          <span class="sr-only">view fullscreen (opens in new tab)</span>
         </a>
       </nav>
     </header>
 
-    <section class="about-popup" aria-label="about the map" hidden>
+    <section
+      id="about-popup"
+      class="about-popup"
+      aria-label="about the map"
+      hidden
+    >
       <header class="about-popup-header">
         <h2>About the Parking Lot Map</h2>
-        <div class="about-popup-close-icon-container">
-          <i
-            class="fa-regular fa-circle-xmark"
-            title="close the about popup"
-          ></i>
-        </div>
+        <button
+          class="about-popup-close-icon-container"
+          title="close the about popup"
+          aria-label="close the about popup"
+        >
+          <i class="fa-regular fa-circle-xmark" aria-hidden="true"></i>
+        </button>
       </header>
 
       <div id="lots-toggle" hidden>

--- a/src/css/theme/_resets.scss
+++ b/src/css/theme/_resets.scss
@@ -16,3 +16,12 @@ body {
   flex-direction: column;
   overflow: hidden;
 }
+
+button {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}

--- a/src/css/vendor/bootstrap.css
+++ b/src/css/vendor/bootstrap.css
@@ -30,28 +30,6 @@ svg:not(:root) {
   overflow: hidden;
 }
 
-button,
-input,
-optgroup,
-select,
-textarea {
-  margin: 0;
-  font: inherit;
-  color: inherit;
-}
-button {
-  overflow: visible;
-}
-button,
-select {
-  text-transform: none;
-}
-
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  padding: 0;
-  border: 0;
-}
 input {
   line-height: normal;
 }
@@ -74,15 +52,6 @@ input[type="search"]::-webkit-search-decoration {
 
 html {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-}
-
-input,
-button,
-select,
-textarea {
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
 }
 
 a {

--- a/src/js/about.ts
+++ b/src/js/about.ts
@@ -8,14 +8,30 @@ const setUpAbout = () => {
   const aboutHeaderIcon = document.querySelector(
     ".header-about-icon-container"
   );
+  const closeIcon = document.querySelector(".about-popup-close-icon-container");
   if (
     !(aboutPopup instanceof HTMLElement) ||
-    !(aboutHeaderIcon instanceof HTMLElement)
+    !(aboutHeaderIcon instanceof HTMLElement) ||
+    !(closeIcon instanceof HTMLElement)
   )
     return;
 
+  const closePopup = () => {
+    aboutPopup.hidden = true;
+    aboutHeaderIcon.setAttribute("aria-expanded", "false");
+  };
+
+  const openPopup = () => {
+    aboutPopup.hidden = false;
+    aboutHeaderIcon.setAttribute("aria-expanded", "true");
+  };
+
   aboutHeaderIcon.addEventListener("click", () => {
-    aboutPopup.hidden = !aboutPopup.hidden;
+    if (aboutPopup.hidden) {
+      openPopup();
+    } else {
+      closePopup();
+    }
   });
 
   // closes window on clicks outside the info popup
@@ -26,14 +42,12 @@ const setUpAbout = () => {
       !aboutHeaderIcon.contains(event.target) &&
       !aboutPopup.contains(event.target)
     ) {
-      aboutPopup.hidden = true;
+      closePopup();
     }
   });
 
-  const closeIcon = document.querySelector(".about-popup-close-icon-container");
-  if (!(closeIcon instanceof HTMLElement)) return;
   closeIcon.addEventListener("click", () => {
-    aboutPopup.hidden = true;
+    closePopup();
   });
 };
 


### PR DESCRIPTION
Improves a few things:

* Uses `button` rather than `div`
* Associates the about icon with the popup
* Uses `.sr-only` to better describe some of the icons
* Hides the icons from screen readers
* Moves the title to the outer div rather than the inner icon, which is useful for sighted users.