### PR TITLE
Don't use Leaflet popup for scorecard

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,6 +277,12 @@
       <p>Copyright 2023 Parking Reform Network - All Rights Reserved</p>
     </section>
 
+    <section
+      id="scorecard-container"
+      class="scorecard-container"
+      role="region"
+    ></section>
+
     <div class="prn-logo">
       <a
         href="https://parkingreform.org/support/"

--- a/src/css/_about.scss
+++ b/src/css/_about.scss
@@ -81,6 +81,4 @@
 
 .about-popup-links-list {
   margin-top: spacing.$element-gap;
-  padding: 0;
-  padding-inline-start: 20px; // Default is 40px
 }

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -97,8 +97,6 @@
   padding-top: spacing.$element-gap;
 
   ul {
-    padding: 0;
-    padding-inline-start: 20px; // Default is 40px
     margin-left: spacing.$container-edge-spacing;
     margin-right: spacing.$container-edge-spacing;
     margin-bottom: spacing.$container-edge-spacing;

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -7,41 +7,21 @@
 @use "theme/zindex";
 @use "header";
 
-.leaflet-pane.leaflet-fixed-pane {
+.scorecard-container {
   z-index: zindex.$scorecard;
-}
-
-.popup-fixed {
   position: fixed;
-  transform: none !important;
-  margin: 0;
-}
+  right: spacing.$map-controls-margin-x;
+  top: calc(header.$header-height + spacing.$map-controls-margin-top);
 
-.leaflet-popup-tip-container {
-  display: none;
-}
-
-.leaflet-popup-content {
-  margin: 0;
-}
-
-.leaflet-popup-content-wrapper {
+  padding: 0;
   width: 260px;
   @include breakpoints.gt-xxs {
     width: 280px;
   }
 
-  padding: 0;
-  padding-right: 1px;
-
-  float: right;
-  position: fixed;
-  right: spacing.$map-controls-margin-x;
-  top: calc(header.$header-height + spacing.$map-controls-margin-top);
-
+  background-color: colors.$white;
   border: borders.$component-border;
   border-radius: borders.$border-radius;
-  box-shadow: none;
   color: colors.$black;
 
   p,
@@ -88,7 +68,6 @@
   align-items: center;
   justify-content: space-between;
 
-  background-color: colors.$white;
   border-left: 0;
   border-right: 0;
   border-top: borders.$component-inner-divider;

--- a/src/css/theme/_resets.scss
+++ b/src/css/theme/_resets.scss
@@ -34,6 +34,8 @@ ul,
 ol {
   margin-top: 0;
   margin-bottom: 10px;
+  padding: 0;
+  padding-inline-start: 20px; // Default is 40px
 }
 
 p,

--- a/src/css/theme/_resets.scss
+++ b/src/css/theme/_resets.scss
@@ -35,3 +35,10 @@ ol {
   margin-top: 0;
   margin-bottom: 10px;
 }
+
+p,
+li,
+dd,
+a {
+  line-height: 1.3;
+}

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -1,5 +1,4 @@
-import { Popup } from "leaflet";
-import { ScoreCard, ScoreCardDetails } from "./types";
+import { ScoreCardDetails } from "./types";
 
 const generateScorecard = (entry: ScoreCardDetails): string => {
   let header = `
@@ -66,23 +65,19 @@ const generateScorecard = (entry: ScoreCardDetails): string => {
   return header + accordion;
 };
 
-const setScorecard = (cityProperties: ScoreCard): void => {
-  const { layer, details } = cityProperties;
-  const scorecard = generateScorecard(details);
-  const popup = new Popup({
-    pane: "fixed",
-    className: "popup-fixed",
-    autoPan: false,
-  }).setContent(scorecard);
-  layer.bindPopup(popup).openPopup();
+const setScorecard = (entry: ScoreCardDetails): void => {
+  const scorecardContainer = document.querySelector(".scorecard-container");
+  if (!scorecardContainer) return;
+  scorecardContainer.innerHTML = generateScorecard(entry);
 };
 
 const setUpScorecardAccordionListener = () => {
-  // The event listener is on `map` because it is never erased, unlike the scorecard
-  // being recreated every time the map moves. This is called "event delegation".
-  const map = document.querySelector("#map");
-  if (!(map instanceof Element)) return;
-  map.addEventListener("click", async (event) => {
+  // The event listener is on `#scorecard-container` because it is never erased,
+  // unlike the scorecard contents being recreated every time the city changes.
+  // This is called "event delegation".
+  const scorecardContainer = document.querySelector("#scorecard-container");
+  if (!(scorecardContainer instanceof Element)) return;
+  scorecardContainer.addEventListener("click", async (event) => {
     const clicked = event.target;
     if (!(clicked instanceof Element)) return;
     const accordionToggle = clicked.closest(".scorecard-accordion-toggle");

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -76,7 +76,6 @@ const STYLES = {
 const createMap = (): Map => {
   const map = new Map("map", {
     layers: [BASE_LAYERS["High contrast"]],
-    closePopupOnClick: false,
   });
   map.attributionControl.setPrefix(
     '<a href="https://parkingreform.org/support/">Parking Reform Network</a>'
@@ -147,7 +146,7 @@ const setUpAutoScorecard = async (
     });
     if (centralCity) {
       DROPDOWN.setChoiceByValue(centralCity);
-      setScorecard(cities[centralCity]);
+      setScorecard(cities[centralCity].details);
       updateIconsShareLink(centralCity);
     }
   });
@@ -207,7 +206,7 @@ const setUpCitiesLayer = async (
   const cityId = cityToggleElement.value;
   setUpAutoScorecard(map, cities, parkingLayer);
   snapToCity(map, cities[cityId].layer);
-  setScorecard(cities[cityId]);
+  setScorecard(cities[cityId].details);
   updateIconsShareLink(cityId);
 };
 

--- a/tests/app/setUpSite.test.ts
+++ b/tests/app/setUpSite.test.ts
@@ -66,7 +66,7 @@ test("correctly load the city score card", async ({ page }) => {
 
     const lines = Array.from(
       document.querySelectorAll(
-        ".leaflet-popup-content-wrapper p, .leaflet-popup-content-wrapper li"
+        ".scorecard-container p, .scorecard-container li"
       )
     )
       .filter(


### PR DESCRIPTION
Benefits of this change:

* The scorecard doesn't disappear temporarily when moving around the map
* Simpler code, such as not having to override Leaflet styling. This will also help with the mandates map

This also DRYs some other code for `<ul>` and line-height.