### PR TITLE
Remove unnecessary scorecard title rules

### DIFF
--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -37,10 +37,6 @@
 }
 
 .scorecard-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
   margin-top: spacing.$container-edge-spacing;
   margin-bottom: spacing.$element-gap;
   margin-left: spacing.$container-edge-spacing;


### PR DESCRIPTION
This was leftover from when the link icon used to be in the scorecard.