### PR TITLE
Add state diagram for fullscreen icon & map changing what's loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,36 +144,60 @@ Go to https://github.com/ParkingReformNetwork/parking-lot-map/actions and open t
 graph TD
     subgraph Nodes
         A[current city]
-        B[map data loaded]
-        C[share link URL]
-        D[scorecard entry]
-        E[map position]
         F[user interaction w/ select element]
-        G[zoom]
+
+        C[share link URL]
+        S[full-screen URL]
+
+        B[map data loaded]
+        D[scorecard entry]
+
+        E[map position]
         H[user scrolling]
+
+        G[zoom]
         R[zoom buttons]
+
         J[scorecard accordion button]
         K[scorecard accordion contents]
+
         L[layer toggle]
         M[map layer]
+
         N[about icon]
         O[about popup]
-        P[map click]
+        P[click outside popup]
         Q[about popup close icon]
+
+        T[AND]
     end
 
     %% Relationships
+    N -->|toggles| O
+    P -->|closes| O
+    Q -->|closes| O
+
+    J -->|toggles| K
+
+    L -->|controls| M
+
     F -->|controls| A
-    A -->|controls| B
+
+    E -->|changes| B
+
+    E -->T
+    G -->T
+    T -->|can change| A
+
     A -->|controls| C
+    A -->|controls| S
+
+    A -->|controls| B
     A -->|controls| D
+
     A -->|resets| E
     A -->|resets| G
+
     H -->|controls| E
     R -->|controls| G
-    J -->|toggles| K
-    L -->|controls| M
-    N -->|toggles| O
-    P -->|closes if open| O
-    Q -->|closes| O
 ```

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Go to https://github.com/ParkingReformNetwork/parking-lot-map/actions and open t
 
 ## State diagram
 
+This shows all possible user interactions on the map, and what triggers what.
+
 ```mermaid
 graph TD
     subgraph Nodes
@@ -155,6 +157,9 @@ graph TD
         E[map position]
         H[user scrolling]
 
+        T[user click on city]
+        U[AND]
+
         G[zoom]
         R[zoom buttons]
 
@@ -168,8 +173,6 @@ graph TD
         O[about popup]
         P[click outside popup]
         Q[about popup close icon]
-
-        T[AND]
     end
 
     %% Relationships
@@ -184,10 +187,11 @@ graph TD
     F -->|controls| A
 
     E -->|changes| B
+    E -->|can change| A
 
-    E -->T
-    G -->T
-    T -->|can change| A
+    T --> U
+    G --> U
+    U --> |changes| A
 
     A -->|controls| C
     A -->|controls| S
@@ -195,8 +199,8 @@ graph TD
     A -->|controls| B
     A -->|controls| D
 
-    A -->|resets| E
-    A -->|resets| G
+    A -->|can reset| E
+    A -->|can reset| G
 
     H -->|controls| E
     R -->|controls| G


### PR DESCRIPTION
I forgot two important features:

* The fullscreen icon uses the URL of the current city
* When scrolling around the map, we load all cities in view. If it's the most-central city, we load it
* When zoomed in enough, clicking inside a city boundary chooses that city and snaps the map to it