### PR TITLE
Use reactive pattern for about and scorecard

### DIFF
--- a/src/js/Observable.ts
+++ b/src/js/Observable.ts
@@ -1,0 +1,35 @@
+/**
+ * A class to manage state of type T.
+ *
+ * UI elements that depend on the state can use `subscribe()` so that whenever the state changes,
+ * the UI is re-calculated. This allows other components to change the state without needing to
+ * know which other parts of the app need to be updated.
+ */
+class Observable<T> {
+  private value: T;
+
+  private subscribers: ((value: T) => void)[] = [];
+
+  constructor(initialValue: T) {
+    this.value = initialValue;
+  }
+
+  getValue(): T {
+    return this.value;
+  }
+
+  setValue(newValue: T): void {
+    this.value = newValue;
+    this.notify();
+  }
+
+  subscribe(callback: (value: T) => void): void {
+    this.subscribers.push(callback);
+  }
+
+  private notify(): void {
+    this.subscribers.forEach((callback) => callback(this.value));
+  }
+}
+
+export default Observable;

--- a/src/js/about.ts
+++ b/src/js/about.ts
@@ -1,50 +1,37 @@
-/* global document, window */
+import Observable from "./Observable";
 
-/**
- * Set up event listeners to open and close the about popup.
- */
+function updateAboutPopupUI(visible: boolean): void {
+  const popup = document.querySelector<HTMLElement>(".about-popup");
+  const icon = document.querySelector(".header-about-icon-container");
+  if (!popup || !icon) return;
+  popup.hidden = !visible;
+  icon.setAttribute("aria-expanded", visible.toString());
+}
+
 function setUpAbout(): void {
-  const aboutPopup = document.querySelector<HTMLElement>(".about-popup");
-  const aboutHeaderIcon = document.querySelector<HTMLElement>(
-    ".header-about-icon-container"
+  const isVisible = new Observable<boolean>(false);
+  isVisible.subscribe(updateAboutPopupUI);
+  updateAboutPopupUI(isVisible.getValue());
+
+  const popup = document.querySelector(".about-popup");
+  const headerIcon = document.querySelector(".header-about-icon-container");
+  const closeIcon = document.querySelector(".about-popup-close-icon-container");
+
+  headerIcon?.addEventListener("click", () =>
+    isVisible.setValue(!isVisible.getValue())
   );
-  const closeIcon = document.querySelector<HTMLElement>(
-    ".about-popup-close-icon-container"
-  );
-  if (!aboutPopup || !aboutHeaderIcon || !closeIcon) return;
+  closeIcon?.addEventListener("click", () => isVisible.setValue(false));
 
-  const closePopup = () => {
-    aboutPopup.hidden = true;
-    aboutHeaderIcon.setAttribute("aria-expanded", "false");
-  };
-
-  const openPopup = () => {
-    aboutPopup.hidden = false;
-    aboutHeaderIcon.setAttribute("aria-expanded", "true");
-  };
-
-  aboutHeaderIcon.addEventListener("click", () => {
-    if (aboutPopup.hidden) {
-      openPopup();
-    } else {
-      closePopup();
-    }
-  });
-
-  // closes window on clicks outside the info popup
+  // Clicks outside the popup close it.
   window.addEventListener("click", (event) => {
     if (
-      !aboutPopup.hidden &&
+      isVisible.getValue() === true &&
       event.target instanceof Element &&
-      !aboutHeaderIcon.contains(event.target) &&
-      !aboutPopup.contains(event.target)
+      !headerIcon?.contains(event.target) &&
+      !popup?.contains(event.target)
     ) {
-      closePopup();
+      isVisible.setValue(false);
     }
-  });
-
-  closeIcon.addEventListener("click", () => {
-    closePopup();
   });
 }
 

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -1,4 +1,5 @@
 import { ScoreCardDetails } from "./types";
+import Observable from "./Observable";
 
 function generateScorecard(entry: ScoreCardDetails): string {
   let header = `
@@ -71,37 +72,37 @@ function setScorecard(entry: ScoreCardDetails): void {
   scorecardContainer.innerHTML = generateScorecard(entry);
 }
 
-function setUpScorecardAccordionListener() {
+function updateScorecardAccordionUI(expanded: boolean): void {
+  const toggle = document.querySelector(".scorecard-accordion-toggle");
+  const content = document.querySelector<HTMLElement>(
+    "#scorecard-accordion-content"
+  );
+  const upIcon = toggle?.querySelector<SVGElement>(".fa-chevron-up");
+  const downIcon = toggle?.querySelector<SVGElement>(".fa-chevron-down");
+  if (!toggle || !content || !upIcon || !downIcon) return;
+
+  toggle.setAttribute("aria-expanded", expanded.toString());
+  content.hidden = !expanded;
+  upIcon.style.display = expanded ? "block" : "none";
+  downIcon.style.display = expanded ? "none" : "block";
+}
+
+function setUpScorecardAccordionListener(): void {
+  const isExpanded = new Observable<boolean>(false);
+  isExpanded.subscribe(updateScorecardAccordionUI);
+  updateScorecardAccordionUI(isExpanded.getValue());
+
   // The event listener is on `#scorecard-container` because it is never erased,
   // unlike the scorecard contents being recreated every time the city changes.
   // This is called "event delegation".
-  const scorecardContainer = document.querySelector<HTMLElement>(
-    "#scorecard-container"
-  );
-  scorecardContainer?.addEventListener("click", async (event) => {
-    const clicked = event.target;
-    if (!(clicked instanceof Element)) return;
-    const accordionToggle = clicked.closest<HTMLButtonElement>(
-      ".scorecard-accordion-toggle"
-    );
-    if (!accordionToggle) return;
-
-    const accordionContent = document.querySelector<HTMLElement>(
-      "#scorecard-accordion-content"
-    );
-    const upIcon = accordionToggle.querySelector<SVGElement>(".fa-chevron-up");
-    const downIcon =
-      accordionToggle.querySelector<SVGElement>(".fa-chevron-down");
-    if (!accordionContent || !upIcon || !downIcon) return;
-
-    const currentlyExpanded =
-      accordionToggle.getAttribute("aria-expanded") === "true";
-    const newState = !currentlyExpanded;
-
-    accordionToggle.setAttribute("aria-expanded", newState.toString());
-    accordionContent.hidden = !newState;
-    upIcon.style.display = newState ? "block" : "none";
-    downIcon.style.display = newState ? "none" : "block";
+  const scorecardContainer = document.querySelector("#scorecard-container");
+  scorecardContainer?.addEventListener("click", (event) => {
+    const clickedElement = event.target;
+    if (!(clickedElement instanceof Element)) return;
+    const toggleClicked = clickedElement.closest(".scorecard-accordion-toggle");
+    if (toggleClicked) {
+      isExpanded.setValue(!isExpanded.getValue());
+    }
   });
 }
 


### PR DESCRIPTION
This PR splits out state management from how to display the UI/DOM. Now, for the scorecard accordion and about popup, we have two distinct functions:

- how to display the UI element given a boolean state
- how to update the boolean state via event listeners, and what the initial value is

Those two functions no longer have tight coupling, which makes them much easier to understand.

Specifically, we use the "Observable" design pattern (aka pub-sub). I also considered switching to Svelte, which has reactivity built-in, but I wanted to start with this simpler approach.

A follow up will use this pattern for the rest of the app.