### PR TITLE
Add `Observable.initialize()`

### DIFF
--- a/src/js/Observable.ts
+++ b/src/js/Observable.ts
@@ -10,6 +10,8 @@ class Observable<T> {
 
   private subscribers: ((value: T) => void)[] = [];
 
+  private isInitialized: boolean = false;
+
   constructor(initialValue: T) {
     this.value = initialValue;
   }
@@ -24,7 +26,18 @@ class Observable<T> {
   }
 
   subscribe(callback: (value: T) => void): void {
+    if (this.isInitialized) {
+      throw new Error("Cannot add subscribers after initialization");
+    }
     this.subscribers.push(callback);
+  }
+
+  initialize(): void {
+    if (this.isInitialized) {
+      throw new Error("Observable is already initialized");
+    }
+    this.isInitialized = true;
+    this.notify();
   }
 
   private notify(): void {

--- a/src/js/about.ts
+++ b/src/js/about.ts
@@ -11,7 +11,7 @@ function updateAboutPopupUI(visible: boolean): void {
 function setUpAbout(): void {
   const isVisible = new Observable<boolean>(false);
   isVisible.subscribe(updateAboutPopupUI);
-  updateAboutPopupUI(isVisible.getValue());
+  isVisible.initialize();
 
   const popup = document.querySelector(".about-popup");
   const headerIcon = document.querySelector(".header-about-icon-container");

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -90,7 +90,7 @@ function updateScorecardAccordionUI(expanded: boolean): void {
 function setUpScorecardAccordionListener(): void {
   const isExpanded = new Observable<boolean>(false);
   isExpanded.subscribe(updateScorecardAccordionUI);
-  updateScorecardAccordionUI(isExpanded.getValue());
+  isExpanded.initialize();
 
   // The event listener is on `#scorecard-container` because it is never erased,
   // unlike the scorecard contents being recreated every time the city changes.


### PR DESCRIPTION
Before, you had to explicitly call every subscriber with the initial state. Now, you can call `myObservable.initialize()` to do that.

Beyond DRY, this is helpful to encapsulate who the subscribers are. For example, for the selectedCity observable, we'll have subscribers from several files and we don't want to have to couple them all together.