### PR TITLE
Fix lot data double loading

### DIFF
--- a/src/js/ParkingLotLoader.ts
+++ b/src/js/ParkingLotLoader.ts
@@ -1,0 +1,53 @@
+import { GeoJSON } from "leaflet";
+import { Feature, Geometry } from "geojson";
+
+import { CityId } from "./types";
+
+interface ParkingLotModules {
+  [key: string]: () => Promise<Feature<Geometry>>;
+}
+
+const parkingLotsModules = import(
+  "~/data/parking-lots/*"
+) as unknown as ParkingLotModules;
+
+export default class ParkingLotLoader {
+  private loadedCities: Set<CityId>;
+
+  // Used to track in-flight requests to load the data so that we don't have
+  // multiple concurrent requests.
+  private loadingPromises: Map<CityId, Promise<void>>;
+
+  constructor() {
+    this.loadedCities = new Set();
+    this.loadingPromises = new Map();
+  }
+
+  load(cityId: CityId, parkingLayer: GeoJSON): Promise<void> {
+    if (this.loadedCities.has(cityId)) {
+      return Promise.resolve();
+    }
+
+    let loadPromise = this.loadingPromises.get(cityId);
+    if (!loadPromise) {
+      loadPromise = ParkingLotLoader.loadCity(cityId, parkingLayer);
+      this.loadingPromises.set(cityId, loadPromise);
+      loadPromise
+        .then(() => this.loadedCities.add(cityId))
+        .finally(() => {
+          this.loadingPromises.delete(cityId);
+        });
+    }
+    return loadPromise;
+  }
+
+  private static async loadCity(
+    cityId: CityId,
+    parkingLayer: GeoJSON
+  ): Promise<void> {
+    const data = await parkingLotsModules[`${cityId}.geojson`]();
+    parkingLayer.addData(data);
+    // Ensure the parking lots do not cover the city boundary.
+    parkingLayer.bringToBack();
+  }
+}

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -1,4 +1,3 @@
-import { Feature, Geometry } from "geojson";
 import { ImageOverlay } from "leaflet";
 
 export type CityId = string; // e.g. `st.-louis-mo`
@@ -23,10 +22,6 @@ export interface ScoreCard {
 }
 
 export type ScoreCards = Record<CityId, ScoreCard>;
-
-export interface ParkingLotModules {
-  [key: string]: () => Promise<Feature<Geometry>>;
-}
 
 export interface DropdownChoice {
   value: string;


### PR DESCRIPTION
Before, it was possible to load parking lot data multiple times due to race conditions. If we had >1 event triggering a map load, then we'd have two requests concurrently.

We need a thread-safe way to only load the data once, i.e. something that keeps track of in-flight requests. We can do that with a `Map<CityId, Promise>`, which makes sure we never have more than one `Promise` for a given city. Once the Promise is complete, we then add the city to `ParkingLotLoader.loadedCities`.