### PR TITLE
Use reactive pattern for city selection state

### DIFF
--- a/src/js/CitySelectionState.ts
+++ b/src/js/CitySelectionState.ts
@@ -3,25 +3,25 @@ import { CityId } from "./types";
 
 import scoreCardsData from "../../data/score-cards.json";
 
-type GlobalState = {
+type CitySelectionState = {
   cityId: CityId;
   shouldSnapMap: boolean;
 };
 
-type GlobalStateObservable = Observable<GlobalState>;
+type CitySelectionObservable = Observable<CitySelectionState>;
 
-function initGlobalState(
+function initCitySelectionState(
   initialCityId: CityId | null,
   fallBackCityId: CityId
-): GlobalStateObservable {
+): CitySelectionObservable {
   const startingCity =
     initialCityId && Object.keys(scoreCardsData).includes(initialCityId)
       ? initialCityId
       : fallBackCityId;
-  return new Observable<GlobalState>({
+  return new Observable<CitySelectionState>({
     cityId: startingCity,
     shouldSnapMap: true,
   });
 }
 
-export { GlobalStateObservable, initGlobalState };
+export { CitySelectionObservable, initCitySelectionState };

--- a/src/js/GlobalState.ts
+++ b/src/js/GlobalState.ts
@@ -1,0 +1,27 @@
+import Observable from "./Observable";
+import { CityId } from "./types";
+
+import scoreCardsData from "../../data/score-cards.json";
+
+type GlobalState = {
+  cityId: CityId;
+  shouldSnapMap: boolean;
+};
+
+type GlobalStateObservable = Observable<GlobalState>;
+
+function initGlobalState(
+  initialCityId: CityId | null,
+  fallBackCityId: CityId
+): GlobalStateObservable {
+  const startingCity =
+    initialCityId && Object.keys(scoreCardsData).includes(initialCityId)
+      ? initialCityId
+      : fallBackCityId;
+  return new Observable<GlobalState>({
+    cityId: startingCity,
+    shouldSnapMap: true,
+  });
+}
+
+export { GlobalStateObservable, initGlobalState };

--- a/src/js/about.ts
+++ b/src/js/about.ts
@@ -11,7 +11,6 @@ function updateAboutPopupUI(visible: boolean): void {
 function setUpAbout(): void {
   const isVisible = new Observable<boolean>(false);
   isVisible.subscribe(updateAboutPopupUI);
-  isVisible.initialize();
 
   const popup = document.querySelector(".about-popup");
   const headerIcon = document.querySelector(".header-about-icon-container");
@@ -33,6 +32,8 @@ function setUpAbout(): void {
       isVisible.setValue(false);
     }
   });
+
+  isVisible.initialize();
 }
 
 export default setUpAbout;

--- a/src/js/dropdown.ts
+++ b/src/js/dropdown.ts
@@ -1,23 +1,22 @@
 import Choices from "choices.js";
 import "choices.js/public/assets/styles/choices.css";
+
 import scoreCardsData from "../../data/score-cards.json";
-import { CityId, ScoreCardDetails, DropdownChoice } from "./types";
+import { ScoreCardDetails, DropdownChoice } from "./types";
+import { GlobalStateObservable } from "./GlobalState";
 
-export const DROPDOWN = new Choices("#city-dropdown", {
-  allowHTML: false,
-  itemSelectText: "",
-  searchEnabled: true,
-  searchResultLimit: 6,
-  searchFields: ["customProperties.city", "customProperties.state"],
-  // Since cities are already alphabetical order in scorecard,
-  // disabling this option allows us to show PRN maps at the top.
-  shouldSort: false,
-});
+function createDropdown(): Choices {
+  const dropdown = new Choices("#city-dropdown", {
+    allowHTML: false,
+    itemSelectText: "",
+    searchEnabled: true,
+    searchResultLimit: 6,
+    searchFields: ["customProperties.city", "customProperties.state"],
+    // Since cities are already alphabetical order in scorecard,
+    // disabling this option allows us to show PRN maps at the top.
+    shouldSort: false,
+  });
 
-function setUpDropdown(
-  initialCityId: CityId | null,
-  fallBackCityId: CityId
-): void {
   const officialCities: DropdownChoice[] = [];
   const communityCities: DropdownChoice[] = [];
   Object.entries(scoreCardsData as Record<string, ScoreCardDetails>).forEach(
@@ -39,7 +38,7 @@ function setUpDropdown(
     }
   );
 
-  DROPDOWN.setChoices([
+  dropdown.setChoices([
     {
       value: "Official maps",
       label: "Official maps",
@@ -49,7 +48,7 @@ function setUpDropdown(
   ]);
 
   if (communityCities.length > 0) {
-    DROPDOWN.setChoices([
+    dropdown.setChoices([
       {
         value: "Community maps",
         label: "Community maps",
@@ -59,11 +58,19 @@ function setUpDropdown(
     ]);
   }
 
-  if (initialCityId && Object.keys(scoreCardsData).includes(initialCityId)) {
-    DROPDOWN.setChoiceByValue(initialCityId);
-  } else {
-    DROPDOWN.setChoiceByValue(fallBackCityId);
-  }
+  return dropdown;
+}
+
+function setUpDropdown(globalState: GlobalStateObservable): void {
+  const dropdown = createDropdown();
+
+  globalState.subscribe(({ cityId }) => dropdown.setChoiceByValue(cityId));
+
+  const selectElement = dropdown.passedElement.element as HTMLSelectElement;
+  selectElement.addEventListener("change", () => {
+    // Note that `change` only triggers for user-driven changes, not programmatic changes.
+    globalState.setValue({ cityId: selectElement.value, shouldSnapMap: true });
+  });
 }
 
 export default setUpDropdown;

--- a/src/js/dropdown.ts
+++ b/src/js/dropdown.ts
@@ -66,9 +66,10 @@ function setUpDropdown(observable: CitySelectionObservable): void {
 
   observable.subscribe(({ cityId }) => dropdown.setChoiceByValue(cityId));
 
+  // Bind user-changes in the dropdown to update the state in CitySelectionObservable.
+  // Note that `change` only triggers for user-driven changes, not programmatic updates.
   const selectElement = dropdown.passedElement.element as HTMLSelectElement;
   selectElement.addEventListener("change", () => {
-    // Note that `change` only triggers for user-driven changes, not programmatic changes.
     observable.setValue({ cityId: selectElement.value, shouldSnapMap: true });
   });
 }

--- a/src/js/dropdown.ts
+++ b/src/js/dropdown.ts
@@ -3,7 +3,7 @@ import "choices.js/public/assets/styles/choices.css";
 
 import scoreCardsData from "../../data/score-cards.json";
 import { ScoreCardDetails, DropdownChoice } from "./types";
-import { GlobalStateObservable } from "./GlobalState";
+import { CitySelectionObservable } from "./CitySelectionState";
 
 function createDropdown(): Choices {
   const dropdown = new Choices("#city-dropdown", {
@@ -61,15 +61,15 @@ function createDropdown(): Choices {
   return dropdown;
 }
 
-function setUpDropdown(globalState: GlobalStateObservable): void {
+function setUpDropdown(observable: CitySelectionObservable): void {
   const dropdown = createDropdown();
 
-  globalState.subscribe(({ cityId }) => dropdown.setChoiceByValue(cityId));
+  observable.subscribe(({ cityId }) => dropdown.setChoiceByValue(cityId));
 
   const selectElement = dropdown.passedElement.element as HTMLSelectElement;
   selectElement.addEventListener("change", () => {
     // Note that `change` only triggers for user-driven changes, not programmatic changes.
-    globalState.setValue({ cityId: selectElement.value, shouldSnapMap: true });
+    observable.setValue({ cityId: selectElement.value, shouldSnapMap: true });
   });
 }
 

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -1,4 +1,5 @@
-import { ScoreCardDetails } from "./types";
+import { GlobalStateObservable } from "./GlobalState";
+import { ScoreCards, ScoreCardDetails } from "./types";
 import Observable from "./Observable";
 
 function generateScorecard(entry: ScoreCardDetails): string {
@@ -66,12 +67,6 @@ function generateScorecard(entry: ScoreCardDetails): string {
   return header + accordion;
 }
 
-function setScorecard(entry: ScoreCardDetails): void {
-  const scorecardContainer = document.querySelector(".scorecard-container");
-  if (!scorecardContainer) return;
-  scorecardContainer.innerHTML = generateScorecard(entry);
-}
-
 function updateScorecardAccordionUI(expanded: boolean): void {
   const toggle = document.querySelector(".scorecard-accordion-toggle");
   const content = document.querySelector<HTMLElement>(
@@ -87,10 +82,9 @@ function updateScorecardAccordionUI(expanded: boolean): void {
   downIcon.style.display = expanded ? "none" : "block";
 }
 
-function setUpScorecardAccordionListener(): void {
+function setUpScorecardAccordion(): void {
   const isExpanded = new Observable<boolean>(false);
   isExpanded.subscribe(updateScorecardAccordionUI);
-  isExpanded.initialize();
 
   // The event listener is on `#scorecard-container` because it is never erased,
   // unlike the scorecard contents being recreated every time the city changes.
@@ -104,6 +98,23 @@ function setUpScorecardAccordionListener(): void {
       isExpanded.setValue(!isExpanded.getValue());
     }
   });
+
+  isExpanded.initialize();
 }
 
-export { setScorecard, setUpScorecardAccordionListener };
+function addScorecardSubscriber(
+  globalState: GlobalStateObservable,
+  cities: ScoreCards
+): void {
+  globalState.subscribe(({ cityId }) => {
+    const scorecardContainer = document.querySelector(".scorecard-container");
+    if (!scorecardContainer) return;
+    scorecardContainer.innerHTML = generateScorecard(cities[cityId].details);
+  });
+
+  // Also set up the accordion UI. It doesn't depend on globalState, so only
+  // needs to run once.
+  setUpScorecardAccordion();
+}
+
+export default addScorecardSubscriber;

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -102,7 +102,7 @@ function setUpScorecardAccordion(): void {
   isExpanded.initialize();
 }
 
-function addScorecardSubscriber(
+export default function addScorecardSubscriber(
   observable: CitySelectionObservable,
   cities: ScoreCards
 ): void {
@@ -116,5 +116,3 @@ function addScorecardSubscriber(
   // needs to run once.
   setUpScorecardAccordion();
 }
-
-export default addScorecardSubscriber;

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -1,4 +1,4 @@
-import { GlobalStateObservable } from "./GlobalState";
+import { CitySelectionObservable } from "./CitySelectionState";
 import { ScoreCards, ScoreCardDetails } from "./types";
 import Observable from "./Observable";
 
@@ -103,10 +103,10 @@ function setUpScorecardAccordion(): void {
 }
 
 function addScorecardSubscriber(
-  globalState: GlobalStateObservable,
+  observable: CitySelectionObservable,
   cities: ScoreCards
 ): void {
-  globalState.subscribe(({ cityId }) => {
+  observable.subscribe(({ cityId }) => {
     const scorecardContainer = document.querySelector(".scorecard-container");
     if (!scorecardContainer) return;
     scorecardContainer.innerHTML = generateScorecard(cities[cityId].details);

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -14,13 +14,14 @@ import { extractCityIdFromUrl } from "./cityId";
 import setUpIcons from "./fontAwesome";
 import maybeDisableFullScreenIcon from "./iframe";
 import setUpAbout from "./about";
-import updateIconsShareLink from "./share";
-import { setScorecard, setUpScorecardAccordionListener } from "./scorecard";
-import setUpDropdown, { DROPDOWN } from "./dropdown";
-
-import cityBoundaries from "~/data/city-boundaries.geojson";
-import scoreCardsDetails from "~/data/score-cards.json";
+import addShareLinkSubscriber from "./share";
+import addScorecardSubscriber from "./scorecard";
+import setUpDropdown from "./dropdown";
 import ParkingLotLoader from "./ParkingLotLoader";
+import { GlobalStateObservable, initGlobalState } from "./GlobalState";
+
+import cityBoundariesGeojson from "~/data/city-boundaries.geojson";
+import scoreCardsDetails from "~/data/score-cards.json";
 
 const MAX_ZOOM = 18;
 const BASE_LAYERS = {
@@ -78,6 +79,16 @@ function createMap(): Map {
   return map;
 }
 
+function addParkingLotLoadSubscriber(
+  globalState: GlobalStateObservable,
+  parkingLayer: GeoJSON,
+  parkingLotLoader: ParkingLotLoader
+): void {
+  globalState.subscribe(({ cityId }) =>
+    parkingLotLoader.load(cityId, parkingLayer)
+  );
+}
+
 /**
  * Centers view to city, but translated down to account for the top UI elements.
  */
@@ -92,55 +103,58 @@ function snapToCity(map: Map, layer: ImageOverlay): void {
   map.setView(translatedCenter);
 }
 
+function addSnapToCitySubscriber(
+  globalState: GlobalStateObservable,
+  map: Map,
+  cities: ScoreCards
+): void {
+  globalState.subscribe((state) => {
+    if (!state.shouldSnapMap) return;
+    snapToCity(map, cities[state.cityId].layer);
+  });
+}
+
 /**
- * Pulls up scorecard for the city closest to the center of view.
- * Also, loads parking lot data of any city in view.
+ * Change the city to whatever is in the center of the map.
  *
- * @param map: The Leaflet map instance.
- * @param cities: Dictionary of cities with layer and scorecard info.
- * @param parkingLayer: GeoJSON layer with parking lot data
+ * Regardless of if the city is chosen, ensure its parking lots are loaded when in view.
  */
-const setUpAutoScorecard = async (
+function setCityByMapPosition(
+  globalState: GlobalStateObservable,
   map: Map,
   cities: ScoreCards,
   parkingLayer: GeoJSON,
   parkingLotLoader: ParkingLotLoader
-): Promise<void> => {
-  map.on("moveend", async () => {
+): void {
+  map.on("moveend", () => {
     let centralCityDistance: number | null = null;
     let centralCity;
-    Object.entries(cities).forEach((city) => {
-      const [cityName, scoreCard] = city;
-      const bounds = scoreCard.layer.getBounds();
+    Object.entries(cities).forEach(([cityId, scorecard]) => {
+      const bounds = scorecard.layer.getBounds();
+      if (!map.getBounds().intersects(bounds)) return;
+      parkingLotLoader.load(cityId, parkingLayer);
 
-      if (bounds && map.getBounds().intersects(bounds)) {
-        const diff = map.getBounds().getCenter().distanceTo(bounds.getCenter());
-        parkingLotLoader.load(cityName, parkingLayer);
-        if (centralCityDistance == null || diff < centralCityDistance) {
-          centralCityDistance = diff;
-          centralCity = cityName;
-        }
+      const distance = map
+        .getBounds()
+        .getCenter()
+        .distanceTo(bounds.getCenter());
+      if (!centralCityDistance || distance < centralCityDistance) {
+        centralCityDistance = distance;
+        centralCity = cityId;
       }
     });
     if (centralCity) {
-      DROPDOWN.setChoiceByValue(centralCity);
-      setScorecard(cities[centralCity].details);
-      updateIconsShareLink(centralCity);
+      globalState.setValue({ cityId: centralCity, shouldSnapMap: false });
     }
   });
-};
+}
 
 /**
- * Load the cities from GeoJson and set up an event listener to change cities when the user
- * toggles the city selection.
+ * Load the cities from GeoJson and associate each city with its layer and scorecard entry.
  */
-async function setUpCitiesLayer(
-  map: Map,
-  parkingLayer: GeoJSON,
-  parkingLotLoader: ParkingLotLoader
-): Promise<void> {
+function createCitiesLayer(map: Map): [GeoJSON, ScoreCards] {
   const cities: ScoreCards = {};
-  const allBoundaries = geoJSON(cityBoundaries, {
+  const allBoundaries = geoJSON(cityBoundariesGeojson, {
     style() {
       return STYLES.cities;
     },
@@ -157,44 +171,28 @@ async function setUpCitiesLayer(
   });
 
   allBoundaries.addTo(map);
+  return [allBoundaries, cities];
+}
 
-  // Set up map to update when city selection changes.
-  const cityToggleElement =
-    document.querySelector<HTMLSelectElement>("#city-dropdown");
-  if (!cityToggleElement) return;
-  cityToggleElement.addEventListener("change", async () => {
-    const cityId = cityToggleElement.value;
-    const { layer } = cities[cityId];
-    if (layer) {
-      snapToCity(map, layer);
-    }
-  });
-
-  // Set up map to update when user clicks within a city's boundary
-  allBoundaries.addEventListener("click", (e) => {
+function setCityOnBoundaryClick(
+  globalState: GlobalStateObservable,
+  map: Map,
+  cityBoundaries: GeoJSON
+): void {
+  cityBoundaries.addEventListener("click", (e) => {
     const currentZoom = map.getZoom();
+    // Only change cities if zoomed in enough.
     if (currentZoom <= 7) return;
     const cityId = e.sourceTarget.feature.properties.id;
-    cityToggleElement.value = cityId;
-    const { layer } = cities[cityId];
-    if (layer) {
-      snapToCity(map, layer);
-    }
+    globalState.setValue({ cityId, shouldSnapMap: true });
   });
-
-  // Load initial city.
-  const cityId = cityToggleElement.value;
-  setUpAutoScorecard(map, cities, parkingLayer, parkingLotLoader);
-  snapToCity(map, cities[cityId].layer);
-  setScorecard(cities[cityId].details);
-  updateIconsShareLink(cityId);
 }
 
 /**
  * Creates a GeoJSON layer to hold all parking lot polygons.
  * Every cites' parking lots will be lazily added to this layer.
  */
-async function setUpParkingLotsLayer(map: Map): Promise<GeoJSON> {
+function createParkingLotsLayer(map: Map): GeoJSON {
   const parkingLayer = geoJSON(undefined, {
     style() {
       return STYLES.parkingLots;
@@ -204,8 +202,7 @@ async function setUpParkingLotsLayer(map: Map): Promise<GeoJSON> {
   if (window.location.href.indexOf("#lots-toggle") === -1) return parkingLayer;
 
   // If `#lots-toggle` is in the URL, we show buttons to toggle parking lots.
-  const toggle: HTMLAnchorElement | null =
-    document.querySelector("#lots-toggle");
+  const toggle = document.querySelector<HTMLElement>("#lots-toggle");
   if (toggle) {
     toggle.hidden = false;
   }
@@ -222,16 +219,31 @@ async function setUpSite(): Promise<void> {
   setUpIcons();
   maybeDisableFullScreenIcon();
   setUpAbout();
-  setUpScorecardAccordionListener();
-
-  const initialCityId = extractCityIdFromUrl(window.location.href);
-  setUpDropdown(initialCityId, "atlanta-ga");
-
-  const parkingLotLoader = new ParkingLotLoader();
 
   const map = createMap();
-  const parkingLayer = await setUpParkingLotsLayer(map);
-  await setUpCitiesLayer(map, parkingLayer, parkingLotLoader);
+  const parkingLayer = createParkingLotsLayer(map);
+  const [cityBoundaries, cities] = createCitiesLayer(map);
+
+  const initialCityId = extractCityIdFromUrl(window.location.href);
+  const globalState = initGlobalState(initialCityId, "atlanta-ga");
+  const parkingLotLoader = new ParkingLotLoader();
+
+  setUpDropdown(globalState);
+  addScorecardSubscriber(globalState, cities);
+  addShareLinkSubscriber(globalState);
+  addSnapToCitySubscriber(globalState, map, cities);
+  addParkingLotLoadSubscriber(globalState, parkingLayer, parkingLotLoader);
+
+  setCityOnBoundaryClick(globalState, map, cityBoundaries);
+  setCityByMapPosition(
+    globalState,
+    map,
+    cities,
+    parkingLayer,
+    parkingLotLoader
+  );
+
+  globalState.initialize();
 
   // There have been some issues on Safari with the map only rendering the top 20%
   // on the first page load. This is meant to address that.

--- a/src/js/share.ts
+++ b/src/js/share.ts
@@ -1,6 +1,6 @@
 /* global document, navigator, window */
 import { determineShareUrl } from "./cityId";
-import { GlobalStateObservable } from "./GlobalState";
+import { CitySelectionObservable } from "./CitySelectionState";
 
 async function copyToClipboard(value: string): Promise<void> {
   try {
@@ -24,8 +24,8 @@ function switchShareIcons(shareIcon: HTMLAnchorElement): void {
   }, 1000);
 }
 
-function addShareLinkSubscriber(globalState: GlobalStateObservable): void {
-  globalState.subscribe(({ cityId }) => {
+function addShareLinkSubscriber(observable: CitySelectionObservable): void {
+  observable.subscribe(({ cityId }) => {
     const shareIcon = document.querySelector<HTMLAnchorElement>(
       ".header-share-icon-container"
     );

--- a/src/js/share.ts
+++ b/src/js/share.ts
@@ -24,7 +24,9 @@ function switchShareIcons(shareIcon: HTMLAnchorElement): void {
   }, 1000);
 }
 
-function addShareLinkSubscriber(observable: CitySelectionObservable): void {
+export default function addShareLinkSubscriber(
+  observable: CitySelectionObservable
+): void {
   observable.subscribe(({ cityId }) => {
     const shareIcon = document.querySelector<HTMLAnchorElement>(
       ".header-share-icon-container"
@@ -42,5 +44,3 @@ function addShareLinkSubscriber(observable: CitySelectionObservable): void {
     fullScreenIcon.href = shareUrl;
   });
 }
-
-export default addShareLinkSubscriber;

--- a/src/js/share.ts
+++ b/src/js/share.ts
@@ -1,6 +1,6 @@
 /* global document, navigator, window */
-import { CityId } from "./types";
 import { determineShareUrl } from "./cityId";
+import { GlobalStateObservable } from "./GlobalState";
 
 async function copyToClipboard(value: string): Promise<void> {
   try {
@@ -24,27 +24,23 @@ function switchShareIcons(shareIcon: HTMLAnchorElement): void {
   }, 1000);
 }
 
-/** Set up the share icon & full screen icons to use the cityId.
- *
- * This function should be called anytime the cityId changes.
- */
-function updateIconsShareLink(cityId: CityId): void {
-  const shareUrl = determineShareUrl(window.location.href, cityId);
+function addShareLinkSubscriber(globalState: GlobalStateObservable): void {
+  globalState.subscribe(({ cityId }) => {
+    const shareIcon = document.querySelector<HTMLAnchorElement>(
+      ".header-share-icon-container"
+    );
+    const fullScreenIcon = document.querySelector<HTMLAnchorElement>(
+      ".header-full-screen-icon-container"
+    );
+    if (!shareIcon || !fullScreenIcon) return;
 
-  const shareIconContainer = document.querySelector<HTMLAnchorElement>(
-    ".header-share-icon-container"
-  );
-  if (!shareIconContainer) return;
-  shareIconContainer.addEventListener("click", async () => {
-    await copyToClipboard(shareUrl);
-    switchShareIcons(shareIconContainer);
+    const shareUrl = determineShareUrl(window.location.href, cityId);
+    shareIcon.addEventListener("click", async () => {
+      await copyToClipboard(shareUrl);
+      switchShareIcons(shareIcon);
+    });
+    fullScreenIcon.href = shareUrl;
   });
-
-  const fullScreenIconContainer = document.querySelector<HTMLAnchorElement>(
-    ".header-full-screen-icon-container"
-  );
-  if (!fullScreenIconContainer) return;
-  fullScreenIconContainer.href = shareUrl;
 }
 
-export default updateIconsShareLink;
+export default addShareLinkSubscriber;


### PR DESCRIPTION
As explained in https://github.com/ParkingReformNetwork/parking-lot-map/pull/254, this separates out state management from how to render the UI. 

This PR adds `CitySelectionState`:

```typescript
type CitySelectionState = {
  cityId: CityId;
  shouldSnapMap: boolean;
};
```

- 5 of our UI elements depend on `CitySelectionState`
- There are 3 ways to update `CitySelectionState`: the dropdown, moving the map position, and clicking a city boundary