### PR TITLE
Dropdown always opens below header

### DIFF
--- a/src/js/dropdown.ts
+++ b/src/js/dropdown.ts
@@ -7,6 +7,7 @@ import { CitySelectionObservable } from "./CitySelectionState";
 
 function createDropdown(): Choices {
   const dropdown = new Choices("#city-dropdown", {
+    position: "bottom",
     allowHTML: false,
     itemSelectText: "",
     searchEnabled: true,


### PR DESCRIPTION
Closes https://github.com/ParkingReformNetwork/parking-lot-map/issues/185. Otherwise, when the viewport is too short, the search would open above the select element.