### PR TITLE
Open all links in a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
             <a
               class="external-link"
               href="https://parkingreform.org/resources/parking-lot-map/"
+              target="_blank"
               >Methodology and key takeaways
               <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
             ></a>
@@ -148,12 +149,16 @@
             <a
               class="external-link"
               href="https://parkingreform.org/resources/mandates-map"
+              target="_blank"
               >PRN's Parking Mandates Map
               <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
             ></a>
           </li>
           <li>
-            <a class="external-link" href="https://parkingreform.org/support/"
+            <a
+              class="external-link"
+              href="https://parkingreform.org/support/"
+              target="_blank"
               >Support this project with a donation
               <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
             ></a>
@@ -208,6 +213,7 @@
             For details on each city boundary,
             <a
               href="https://parkingreform.org/resources/parking-lot-map/parking-lot-map-boundary-methodology/"
+              target="_blank"
               >see this detailed methodology</a
             >.
           </p>
@@ -223,6 +229,7 @@
             example, Wordpress sites should use a
             <a
               href="https://wordpress.com/support/wordpress-editor/blocks/custom-html-block/"
+              target="_blank"
               >Custom HTML code block</a
             >. Try searching for the name of your website provider and 'iframe',
             like 'Squarespace iframe'.
@@ -250,29 +257,47 @@
       <h3>Acknowledgments</h3>
       <p>
         This map was developed by
-        <a href="https://www.linkedin.com/in/thomas-carpenito/"
+        <a href="https://www.linkedin.com/in/thomas-carpenito/" target="_blank"
           >Thomas Carpenito</a
         >
         with the assistance of
-        <a href="https://www.linkedin.com/in/arellanoeric/">Eric Arellano</a>,
-        <a href="https://www.linkedin.com/in/tung-lin-bb1745163/">Tung Lin</a>,
-        <a href="https://www.geocadder.bg/en/">Geocadder</a>,
-        <a href="https://www.linkedin.com/in/davidrhunt/">David Hunt</a>,
-        <a href="https://www.linkedin.com/in/ellen-schwartz-614847132/"
+        <a href="https://www.linkedin.com/in/arellanoeric/" target="_blank"
+          >Eric Arellano</a
+        >,
+        <a
+          href="https://www.linkedin.com/in/tung-lin-bb1745163/"
+          target="_blank"
+          >Tung Lin</a
+        >, <a href="https://www.geocadder.bg/en/" target="_blank">Geocadder</a>,
+        <a href="https://www.linkedin.com/in/davidrhunt/" target="_blank"
+          >David Hunt</a
+        >,
+        <a
+          href="https://www.linkedin.com/in/ellen-schwartz-614847132/"
+          target="_blank"
           >Ellen Schwartz</a
         >,
-        <a href="https://www.linkedin.com/in/tony-jordan-pdx/">Tony Jordan</a>,
-        <a href="https://www.linkedin.com/in/pameeela/">Pamela Barone</a>,
-        <a href="https://nathanwyand.com/">Nathan Wyand</a>, and
-        <a href="https://www.linkedin.com/in/justin-sawyer-59b0525/"
+        <a href="https://www.linkedin.com/in/tony-jordan-pdx/" target="_blank"
+          >Tony Jordan</a
+        >,
+        <a href="https://www.linkedin.com/in/pameeela/" target="_blank"
+          >Pamela Barone</a
+        >, <a href="https://nathanwyand.com/" target="_blank">Nathan Wyand</a>,
+        and
+        <a
+          href="https://www.linkedin.com/in/justin-sawyer-59b0525/"
+          target="_blank"
           >Justin Sawyer</a
         >. The map data come from
-        <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>. The
-        map is built using <a href="https://leafletjs.com/">Leaflet</a>. The map
+        <a href="https://www.openstreetmap.org/copyright" target="_blank"
+          >OpenStreetMap</a
+        >. The map is built using
+        <a href="https://leafletjs.com/" target="_blank">Leaflet</a>. The map
         tiles are developed by
-        <a href="https://www.stadiamaps.com/">Stadia Maps</a>,
-        <a href="http://stamen.com/">Stamen Design</a>,
-        <a href="https://openmaptiles.org/">OpenMapTiles</a>, and Google Maps.
+        <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a>,
+        <a href="http://stamen.com/" target="_blank">Stamen Design</a>,
+        <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>,
+        and Google Maps.
       </p>
       <p>Copyright 2023 Parking Reform Network - All Rights Reserved</p>
     </section>
@@ -287,6 +312,7 @@
       <a
         href="https://parkingreform.org/support/"
         aria-label="Support Parking Reform Network"
+        target="_blank"
         ><img
           src="./assets/images/prn-logo.png"
           alt="Parking Reform Network logo"

--- a/index.html
+++ b/index.html
@@ -212,9 +212,11 @@
           <p>
             For details on each city boundary,
             <a
+              class="external-link"
               href="https://parkingreform.org/resources/parking-lot-map/parking-lot-map-boundary-methodology/"
               target="_blank"
-              >see this detailed methodology</a
+              >see this detailed methodology
+              <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
             >.
           </p>
         </dd>
@@ -228,9 +230,11 @@
             First, find how to embed iframes with your website provider. For
             example, Wordpress sites should use a
             <a
+              class="external-link"
               href="https://wordpress.com/support/wordpress-editor/blocks/custom-html-block/"
               target="_blank"
-              >Custom HTML code block</a
+              >Custom HTML code block
+              <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
             >. Try searching for the name of your website provider and 'iframe',
             like 'Squarespace iframe'.
           </p>
@@ -257,47 +261,102 @@
       <h3>Acknowledgments</h3>
       <p>
         This map was developed by
-        <a href="https://www.linkedin.com/in/thomas-carpenito/" target="_blank"
-          >Thomas Carpenito</a
-        >
+        <a
+          class="external-link"
+          href="https://www.linkedin.com/in/thomas-carpenito/"
+          target="_blank"
+          >Thomas Carpenito
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
+        ></a>
         with the assistance of
-        <a href="https://www.linkedin.com/in/arellanoeric/" target="_blank"
-          >Eric Arellano</a
+        <a
+          class="external-link"
+          href="https://www.linkedin.com/in/arellanoeric/"
+          target="_blank"
+          >Eric Arellano
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
         >,
         <a
+          class="external-link"
           href="https://www.linkedin.com/in/tung-lin-bb1745163/"
           target="_blank"
-          >Tung Lin</a
-        >, <a href="https://www.geocadder.bg/en/" target="_blank">Geocadder</a>,
-        <a href="https://www.linkedin.com/in/davidrhunt/" target="_blank"
-          >David Hunt</a
+          >Tung Lin
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
         >,
         <a
+          class="external-link"
+          href="https://www.geocadder.bg/en/"
+          target="_blank"
+          >Geocadder
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >,
+        <a
+          class="external-link"
+          href="https://www.linkedin.com/in/davidrhunt/"
+          target="_blank"
+          >David Hunt
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >,
+        <a
+          class="external-link"
           href="https://www.linkedin.com/in/ellen-schwartz-614847132/"
           target="_blank"
-          >Ellen Schwartz</a
+          >Ellen Schwartz
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
         >,
-        <a href="https://www.linkedin.com/in/tony-jordan-pdx/" target="_blank"
-          >Tony Jordan</a
-        >,
-        <a href="https://www.linkedin.com/in/pameeela/" target="_blank"
-          >Pamela Barone</a
-        >, <a href="https://nathanwyand.com/" target="_blank">Nathan Wyand</a>,
-        and
         <a
+          class="external-link"
+          href="https://www.linkedin.com/in/tony-jordan-pdx/"
+          target="_blank"
+          >Tony Jordan
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >,
+        <a
+          class="external-link"
+          href="https://www.linkedin.com/in/pameeela/"
+          target="_blank"
+          >Pamela Barone
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >,
+        <a class="external-link" href="https://nathanwyand.com/" target="_blank"
+          >Nathan Wyand
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >, and
+        <a
+          class="external-link"
           href="https://www.linkedin.com/in/justin-sawyer-59b0525/"
           target="_blank"
-          >Justin Sawyer</a
+          >Justin Sawyer
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
         >. The map data come from
-        <a href="https://www.openstreetmap.org/copyright" target="_blank"
-          >OpenStreetMap</a
+        <a
+          class="external-link"
+          href="https://www.openstreetmap.org/copyright"
+          target="_blank"
+          >OpenStreetMap
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
         >. The map is built using
-        <a href="https://leafletjs.com/" target="_blank">Leaflet</a>. The map
-        tiles are developed by
-        <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a>,
-        <a href="http://stamen.com/" target="_blank">Stamen Design</a>,
-        <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>,
-        and Google Maps.
+        <a class="external-link" href="https://leafletjs.com/" target="_blank"
+          >Leaflet <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >. The map tiles are developed by
+        <a
+          class="external-link"
+          href="https://www.stadiamaps.com/"
+          target="_blank"
+          >Stadia Maps
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >,
+        <a class="external-link" href="http://stamen.com/" target="_blank"
+          >Stamen Design
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >,
+        <a
+          class="external-link"
+          href="https://openmaptiles.org/"
+          target="_blank"
+          >OpenMapTiles
+          <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a
+        >, and Google Maps.
       </p>
       <p>Copyright 2023 Parking Reform Network - All Rights Reserved</p>
     </section>


### PR DESCRIPTION
The app is usually accessed via an iframe. If you click links currently, the new page is in the iframe itself. This is really confusing. We could use `target=_top` to replace the current page, but Tony has said in the past that we should go to a new tab.

We now consistently use the up-right arrow icon with every external link to make more explicit that the links go to a new tab.

<img width="792" alt="Screenshot 2024-08-02 at 8 50 24 AM" src="https://github.com/user-attachments/assets/7640e41b-b4f3-4519-9d60-34a7e8f730f9">
