### PR TITLE
Fix target being declared in wrong place

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,6 @@
     "prettier": "^3.4.2",
     "typescript": "^5.7.3"
   },
-  "targets": {
-    "default": {
-      "publicUrl": "./"
-    }
-  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/packages/primary/package.json
+++ b/packages/primary/package.json
@@ -17,5 +17,10 @@
     "choices.js": "^10.2.0",
     "leaflet": "~1.9.3"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "targets": {
+    "default": {
+      "publicUrl": "./"
+    }
+  }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,10 +12,5 @@
     "choices.js": "^10.2.0",
     "leaflet": "~1.9.3"
   },
-  "devDependencies": {},
-  "targets": {
-    "default": {
-      "publicUrl": "./"
-    }
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
Proper proper fix of https://github.com/ParkingReformNetwork/parking-lot-map/pull/299. I had put the target on packages/shared, not packages/primary 🤦 This config fixes the HTML and logo to not have a prefix, rather than `/`.