### PR TITLE
Support new Connecticut city IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@playwright/test": "^1.49.1",
     "@types/geojson": "^7946.0.15",
     "@types/leaflet": "^1.9.16",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.10.5",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "eslint": "^8.37.0",

--- a/packages/ct/data/city-boundaries.geojson
+++ b/packages/ct/data/city-boundaries.geojson
@@ -11,7 +11,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "hartford-ct"
+        "id": "hartford"
       },
       "geometry": {
         "type": "Polygon",
@@ -171,7 +171,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "new-haven-ct"
+        "id": "new-haven"
       },
       "geometry": {
         "type": "Polygon",

--- a/packages/ct/data/city-stats.json
+++ b/packages/ct/data/city-stats.json
@@ -1,22 +1,22 @@
 {
-  "hartford-ct": {
-    "name": "Hartford, CT",
+  "hartford": {
+    "name": "Hartford",
     "percentage": "26%",
     "cityType": "core",
     "population": "121,054",
     "urbanizedAreaPopulation": "977,158",
     "parkingScore": "53",
-    "reforms": "implemented",
+    "reforms": "adopted",
     "url": "https://parkingreform.org/mandates-map/city_detail/Hartford_CT.html"
   },
-  "new-haven-ct": {
-    "name": "New Haven, CT",
+  "new-haven": {
+    "name": "New Haven",
     "percentage": "34%",
     "cityType": "principal",
     "population": "134,023",
     "urbanizedAreaPopulation": "561,456",
     "parkingScore": null,
-    "reforms": "implemented",
+    "reforms": "adopted",
     "url": "https://parkingreform.org/mandates-map/city_detail/NewHaven_CT.html"
   }
 }

--- a/packages/ct/data/parking-lots/hartford.geojson
+++ b/packages/ct/data/parking-lots/hartford.geojson
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "properties": {
-    "id": "hartford-ct"
+    "id": "hartford"
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/packages/ct/data/parking-lots/new-haven.geojson
+++ b/packages/ct/data/parking-lots/new-haven.geojson
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "properties": {
-    "id": "new-haven-ct"
+    "id": "new-haven"
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/packages/ct/src/js/main.ts
+++ b/packages/ct/src/js/main.ts
@@ -13,6 +13,6 @@ export default async function initApp(): Promise<void> {
       boundaries: CITY_BOUNDARIES_GEOJSON,
       parkingLots: PARKING_LOT_GEOJSON_MODULES,
     },
-    initialCity: "hartford-ct",
+    initialCity: "hartford",
   });
 }

--- a/packages/primary/data/city-boundaries.geojson
+++ b/packages/primary/data/city-boundaries.geojson
@@ -9868,7 +9868,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "st.-louis-mo"
+        "id": "st-louis-mo"
       },
       "geometry": {
         "type": "Polygon",
@@ -9969,7 +9969,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "st.-petersburg-fl"
+        "id": "st-petersburg-fl"
       },
       "geometry": {
         "type": "Polygon",

--- a/packages/primary/data/city-stats.json
+++ b/packages/primary/data/city-stats.json
@@ -930,7 +930,7 @@
     "reforms": "implemented",
     "url": "https://parkingreform.org/mandates-map/city_detail/Seattle_WA.html"
   },
-  "st.-louis-mo": {
+  "st-louis-mo": {
     "name": "St. Louis, MO",
     "percentage": "27%",
     "cityType": "core",
@@ -940,7 +940,7 @@
     "reforms": "implemented",
     "url": "https://parkingreform.org/mandates-map/city_detail/St.Louis_MO.html"
   },
-  "st.-petersburg-fl": {
+  "st-petersburg-fl": {
     "name": "St. Petersburg, FL",
     "percentage": "28%",
     "cityType": "principal",

--- a/packages/primary/data/parking-lots/st-louis-mo.geojson
+++ b/packages/primary/data/parking-lots/st-louis-mo.geojson
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "properties": {
-    "id": "st.-louis-mo"
+    "id": "st-louis-mo"
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/packages/primary/data/parking-lots/st-petersburg-fl.geojson
+++ b/packages/primary/data/parking-lots/st-petersburg-fl.geojson
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "properties": {
-    "id": "st.-petersburg-fl"
+    "id": "st-petersburg-fl"
   },
   "geometry": {
     "type": "MultiPolygon",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,8 @@
     "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "choices.js": "^10.2.0",
-    "leaflet": "~1.9.3"
+    "leaflet": "~1.9.3",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {}
 }

--- a/packages/shared/src/js/cityId.ts
+++ b/packages/shared/src/js/cityId.ts
@@ -1,29 +1,30 @@
+import { kebabCase } from "lodash-es";
+
 import type { CityId } from "./types";
 
 /**
  * Extract the city ID from the URL's `#`, if present.
  */
 export function extractCityIdFromUrl(windowUrl: string): string | null {
-  return windowUrl.indexOf("#parking-reform-map=") === -1
-    ? null
-    : windowUrl.split("#")[1].split("=")[1].toLowerCase();
+  if (windowUrl.indexOf("#parking-reform-map=") === -1) return null;
+  return windowUrl.split("#")[1].split("=")[1].toLowerCase().replace(".", "");
 }
 
 /**
  * Parse the geojson's `Name` property into the city ID.
  *
  * @param jsonCityName: the `Name` property from JSON, e.g. `"My City, AZ"`
- * @return: the city ID, e.g. `st.-louis-mo`.
+ * @return: the city ID, e.g. `st-louis-mo`.
  */
 export function parseCityIdFromJson(jsonCityName: string): string {
-  return jsonCityName.toLowerCase().replace(/ /g, "-").replace(/,/g, "");
+  return kebabCase(jsonCityName);
 }
 
 /**
  * Determine what URL to use to share the current city.
  *
  * @param windowUrl: the current page's URL
- * @param cityId: e.g. `st.-louis-mo`
+ * @param cityId: e.g. `st-louis-mo`
  * @return: the URL to share
  */
 export function determineShareUrl(windowUrl: string, cityId: CityId): string {

--- a/packages/shared/src/js/types.ts
+++ b/packages/shared/src/js/types.ts
@@ -7,9 +7,9 @@ import type {
   GeoJsonProperties,
 } from "geojson";
 
-/// The slugified ID, e.g. `st.-louis-mo` or `hartford`.
+/// The slugified ID, e.g. `st-louis-mo` or `hartford`.
 /// (The state code is missing for state-specific maps like CT.)
-export type CityId = string; // e.g. `st.-louis-mo`
+export type CityId = string;
 
 export interface CityStats {
   name: string;

--- a/packages/shared/tests/cityId.test.ts
+++ b/packages/shared/tests/cityId.test.ts
@@ -32,6 +32,9 @@ test.describe("extractCityIdFromUrl()", () => {
         "https://parking.org#parking-reform-map=CITY-OF-SHOUP",
       ),
     ).toEqual("city-of-shoup");
+    expect(
+      extractCityIdFromUrl("https://parking.org#parking-reform-map=st.-louis"),
+    ).toEqual("st-louis");
   });
 });
 
@@ -41,7 +44,13 @@ test("parseCityIdFromJson() extracts the city", () => {
   expect(parseCityIdFromJson("Saint Shoup Village, AZ")).toEqual(
     "saint-shoup-village-az",
   );
+  expect(parseCityIdFromJson("St. Shoup Village, AZ")).toEqual(
+    "st-shoup-village-az",
+  );
   expect(parseCityIdFromJson("No state")).toEqual("no-state");
+  expect(parseCityIdFromJson("Hartford - rail station")).toEqual(
+    "hartford-rail-station",
+  );
 });
 
 test.describe("determineShareUrl()", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
     devDependencies:
       "@parcel/compressor-brotli":
         specifier: ~2.12.0
-        version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+        version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/compressor-gzip":
         specifier: ~2.12.0
         version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
@@ -18,7 +18,7 @@ importers:
         version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(typescript@5.7.3)
       "@parcel/resolver-glob":
         specifier: ~2.12.0
-        version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+        version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/transformer-json":
         specifier: ~2.12.0
         version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
@@ -34,6 +34,9 @@ importers:
       "@types/leaflet":
         specifier: ^1.9.16
         version: 1.9.16
+      "@types/lodash-es":
+        specifier: ^4.17.12
+        version: 4.17.12
       "@types/node":
         specifier: ^22.10.5
         version: 22.10.5
@@ -69,7 +72,7 @@ importers:
     dependencies:
       "@parcel/resolver-glob":
         specifier: ~2.12.0
-        version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+        version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@prn-parking-lots/shared":
         specifier: workspace:*
         version: link:../shared
@@ -84,7 +87,7 @@ importers:
     dependencies:
       "@parcel/resolver-glob":
         specifier: ~2.12.0
-        version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+        version: 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@prn-parking-lots/shared":
         specifier: workspace:*
         version: link:../shared
@@ -125,6 +128,9 @@ importers:
       leaflet:
         specifier: ~1.9.3
         version: 1.9.4
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
 
 packages:
   "@babel/code-frame@7.26.2":
@@ -1267,6 +1273,18 @@ packages:
     resolution:
       {
         integrity: sha512-wzZoyySUxkgMZ0ihJ7IaUIblG8Rdc8AbbZKLneyn+QjYsj5q1QU7TEKYqwTr10BGSzY5LI7tJk9Ifo+mEjdFRw==,
+      }
+
+  "@types/lodash-es@4.17.12":
+    resolution:
+      {
+        integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==,
+      }
+
+  "@types/lodash@4.17.14":
+    resolution:
+      {
+        integrity: sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==,
       }
 
   "@types/node@22.10.5":
@@ -2809,6 +2827,12 @@ packages:
       }
     engines: { node: ">=10" }
 
+  lodash-es@4.17.21:
+    resolution:
+      {
+        integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==,
+      }
+
   lodash.merge@4.6.2:
     resolution:
       {
@@ -3951,7 +3975,7 @@ snapshots:
     dependencies:
       "@parcel/diagnostic": 2.12.0
       "@parcel/graph": 3.2.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/rust": 2.12.0
       "@parcel/utils": 2.12.0
       nullthrows: 1.1.1
@@ -3970,21 +3994,22 @@ snapshots:
     dependencies:
       chalk: 4.1.2
 
-  "@parcel/compressor-brotli@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
+  "@parcel/compressor-brotli@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@parcel/core"
+      - "@swc/helpers"
 
   "@parcel/compressor-gzip@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@parcel/core"
 
   "@parcel/compressor-raw@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@parcel/core"
 
@@ -4043,13 +4068,13 @@ snapshots:
       "@parcel/graph": 3.2.0
       "@parcel/logger": 2.12.0
       "@parcel/package-manager": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/profiler": 2.12.0
       "@parcel/rust": 2.12.0
       "@parcel/source-map": 2.1.1
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
-      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       abortcontroller-polyfill: 1.7.8
       base-x: 3.0.10
       browserslist: 4.24.4
@@ -4077,7 +4102,7 @@ snapshots:
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       "@parcel/watcher": 2.5.0
-      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@swc/helpers"
 
@@ -4097,7 +4122,7 @@ snapshots:
   "@parcel/namer-default@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - "@parcel/core"
@@ -4117,7 +4142,7 @@ snapshots:
   "@parcel/optimizer-css@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/source-map": 2.1.1
       "@parcel/utils": 2.12.0
       browserslist: 4.24.4
@@ -4128,7 +4153,7 @@ snapshots:
 
   "@parcel/optimizer-htmlnano@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(typescript@5.7.3)":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       htmlnano: 2.1.1(svgo@2.8.0)(typescript@5.7.3)
       nullthrows: 1.1.1
       posthtml: 0.16.6
@@ -4148,15 +4173,15 @@ snapshots:
     dependencies:
       "@parcel/core": 2.12.0(@swc/helpers@0.5.15)
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/rust": 2.12.0
       "@parcel/utils": 2.12.0
-      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
 
   "@parcel/optimizer-svgo@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       svgo: 2.8.0
     transitivePeerDependencies:
@@ -4165,7 +4190,7 @@ snapshots:
   "@parcel/optimizer-swc@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/source-map": 2.1.1
       "@parcel/utils": 2.12.0
       "@swc/core": 1.10.4(@swc/helpers@0.5.15)
@@ -4183,7 +4208,7 @@ snapshots:
       "@parcel/node-resolver-core": 3.3.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
-      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@swc/core": 1.10.4(@swc/helpers@0.5.15)
       semver: 7.6.3
     transitivePeerDependencies:
@@ -4192,7 +4217,7 @@ snapshots:
   "@parcel/packager-css@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/source-map": 2.1.1
       "@parcel/utils": 2.12.0
       lightningcss: 1.29.1
@@ -4202,7 +4227,7 @@ snapshots:
 
   "@parcel/packager-html@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       nullthrows: 1.1.1
@@ -4213,7 +4238,7 @@ snapshots:
   "@parcel/packager-js@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/rust": 2.12.0
       "@parcel/source-map": 2.1.1
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
@@ -4225,13 +4250,13 @@ snapshots:
 
   "@parcel/packager-raw@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@parcel/core"
 
   "@parcel/packager-svg@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       posthtml: 0.16.6
@@ -4240,15 +4265,16 @@ snapshots:
 
   "@parcel/packager-wasm@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@parcel/core"
 
-  "@parcel/plugin@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
+  "@parcel/plugin@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)":
     dependencies:
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@parcel/core"
+      - "@swc/helpers"
 
   "@parcel/profiler@2.12.0":
     dependencies:
@@ -4258,7 +4284,7 @@ snapshots:
 
   "@parcel/reporter-cli@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       chalk: 4.1.2
@@ -4268,14 +4294,14 @@ snapshots:
 
   "@parcel/reporter-dev-server@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
     transitivePeerDependencies:
       - "@parcel/core"
 
   "@parcel/reporter-tracer@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       chrome-trace-event: 1.0.4
       nullthrows: 1.1.1
@@ -4285,23 +4311,24 @@ snapshots:
   "@parcel/resolver-default@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/node-resolver-core": 3.3.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@parcel/core"
 
-  "@parcel/resolver-glob@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
+  "@parcel/resolver-glob@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)":
     dependencies:
       "@parcel/diagnostic": 2.12.0
       "@parcel/node-resolver-core": 3.3.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - "@parcel/core"
+      - "@swc/helpers"
 
   "@parcel/runtime-browser-hmr@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
     transitivePeerDependencies:
       - "@parcel/core"
@@ -4309,7 +4336,7 @@ snapshots:
   "@parcel/runtime-js@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -4317,7 +4344,7 @@ snapshots:
 
   "@parcel/runtime-react-refresh@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       react-error-overlay: 6.0.9
       react-refresh: 0.9.0
@@ -4326,7 +4353,7 @@ snapshots:
 
   "@parcel/runtime-service-worker@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -4341,7 +4368,7 @@ snapshots:
   "@parcel/transformer-babel@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/source-map": 2.1.1
       "@parcel/utils": 2.12.0
       browserslist: 4.24.4
@@ -4354,7 +4381,7 @@ snapshots:
   "@parcel/transformer-css@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/source-map": 2.1.1
       "@parcel/utils": 2.12.0
       browserslist: 4.24.4
@@ -4366,7 +4393,7 @@ snapshots:
   "@parcel/transformer-html@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/rust": 2.12.0
       nullthrows: 1.1.1
       posthtml: 0.16.6
@@ -4380,20 +4407,20 @@ snapshots:
   "@parcel/transformer-image@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/core": 2.12.0(@swc/helpers@0.5.15)
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
-      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       nullthrows: 1.1.1
 
   "@parcel/transformer-js@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/core": 2.12.0(@swc/helpers@0.5.15)
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/rust": 2.12.0
       "@parcel/source-map": 2.1.1
       "@parcel/utils": 2.12.0
-      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@swc/helpers": 0.5.15
       browserslist: 4.24.4
       nullthrows: 1.1.1
@@ -4402,7 +4429,7 @@ snapshots:
 
   "@parcel/transformer-json@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       json5: 2.2.3
     transitivePeerDependencies:
       - "@parcel/core"
@@ -4410,7 +4437,7 @@ snapshots:
   "@parcel/transformer-postcss@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/rust": 2.12.0
       "@parcel/utils": 2.12.0
       clone: 2.1.2
@@ -4422,7 +4449,7 @@ snapshots:
 
   "@parcel/transformer-posthtml@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       nullthrows: 1.1.1
       posthtml: 0.16.6
@@ -4434,13 +4461,13 @@ snapshots:
 
   "@parcel/transformer-raw@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
     transitivePeerDependencies:
       - "@parcel/core"
 
   "@parcel/transformer-react-refresh-wrap@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       react-refresh: 0.9.0
     transitivePeerDependencies:
@@ -4448,7 +4475,7 @@ snapshots:
 
   "@parcel/transformer-sass@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/source-map": 2.1.1
       sass: 1.83.1
     transitivePeerDependencies:
@@ -4457,7 +4484,7 @@ snapshots:
   "@parcel/transformer-svg@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
     dependencies:
       "@parcel/diagnostic": 2.12.0
-      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/plugin": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/rust": 2.12.0
       nullthrows: 1.1.1
       posthtml: 0.16.6
@@ -4474,7 +4501,7 @@ snapshots:
       "@parcel/fs": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/package-manager": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/source-map": 2.1.1
-      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))
+      "@parcel/workers": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       utility-types: 3.11.0
     transitivePeerDependencies:
       - "@parcel/core"
@@ -4551,7 +4578,7 @@ snapshots:
       "@parcel/watcher-win32-ia32": 2.5.0
       "@parcel/watcher-win32-x64": 2.5.0
 
-  "@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))":
+  "@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)":
     dependencies:
       "@parcel/core": 2.12.0(@swc/helpers@0.5.15)
       "@parcel/diagnostic": 2.12.0
@@ -4560,6 +4587,8 @@ snapshots:
       "@parcel/types": 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)
       "@parcel/utils": 2.12.0
       nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - "@swc/helpers"
 
   "@playwright/test@1.49.1":
     dependencies:
@@ -4633,6 +4662,12 @@ snapshots:
   "@types/leaflet@1.9.16":
     dependencies:
       "@types/geojson": 7946.0.15
+
+  "@types/lodash-es@4.17.12":
+    dependencies:
+      "@types/lodash": 4.17.14
+
+  "@types/lodash@4.17.14": {}
 
   "@types/node@22.10.5":
     dependencies:
@@ -5689,6 +5724,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.21: {}
 
   lodash.merge@4.6.2: {}
 


### PR DESCRIPTION
The CT map will have entries like `Hartford - rail station`, which should convert to `hartford-rail-station`. We can do that with Lodash's kebabCase.

That results in changing `st.` to become `st`, which is a good change anyways. We ensure we still pre-load the correct place if someone uses an anchor with the old style of `st.`.