### PR TITLE
Dropdown search can handle CT city names

### DIFF
--- a/packages/shared/src/js/city-ui/dropdown.ts
+++ b/packages/shared/src/js/city-ui/dropdown.ts
@@ -1,33 +1,26 @@
-import Choices from "choices.js";
+import ChoicesJS from "choices.js";
 
-import type { CityStatsCollection, DropdownChoice } from "../model/types";
+import { DropdownChoice, createChoice } from "./dropdownUtils";
+import type { CityStatsCollection } from "../model/types";
 import { ViewStateObservable } from "../state/ViewState";
 
-function createDropdown(cityStatsData: CityStatsCollection): Choices {
-  const dropdown = new Choices("#city-dropdown", {
+function createDropdown(cityStatsData: CityStatsCollection): ChoicesJS {
+  const dropdown = new ChoicesJS("#city-dropdown", {
     position: "bottom",
     allowHTML: false,
     itemSelectText: "",
     searchEnabled: true,
     searchResultLimit: 6,
-    searchFields: ["customProperties.city", "customProperties.state"],
-    // Since cities are already alphabetical order in scorecard,
-    // disabling this option allows us to show PRN maps at the top.
+    searchFields: ["customProperties.city", "customProperties.context"],
+    // Disabling this option allows us to properly handle search groups.
+    // We already sort entries in the JSON file.
     shouldSort: false,
   });
 
   const officialCities: DropdownChoice[] = [];
   const communityCities: DropdownChoice[] = [];
   Object.entries(cityStatsData).forEach(([id, { name, contribution }]) => {
-    const [city, state] = name.split(", ");
-    const entry: DropdownChoice = {
-      value: id,
-      label: name,
-      customProperties: {
-        city,
-        state,
-      },
-    };
+    const entry = createChoice(id, name);
     if (contribution) {
       communityCities.push(entry);
     } else {

--- a/packages/shared/src/js/city-ui/dropdownUtils.ts
+++ b/packages/shared/src/js/city-ui/dropdownUtils.ts
@@ -1,0 +1,23 @@
+import type { CityId } from "../model/types";
+
+export interface DropdownChoice {
+  value: string;
+  label: string;
+  customProperties: {
+    city: string;
+    /// E.g. "NY" or "rail station"
+    context: string;
+  };
+}
+
+export function createChoice(id: CityId, name: string): DropdownChoice {
+  const [city, context] = name.split(/,\s|\s-\s/);
+  return {
+    value: id,
+    label: name,
+    customProperties: {
+      city,
+      context: context ?? "",
+    },
+  };
+}

--- a/packages/shared/src/js/model/types.ts
+++ b/packages/shared/src/js/model/types.ts
@@ -32,15 +32,6 @@ export interface CityEntry {
 
 export type CityEntryCollection = Record<CityId, CityEntry>;
 
-export interface DropdownChoice {
-  value: string;
-  label: string;
-  customProperties: {
-    city: string;
-    state: string;
-  };
-}
-
 export type CityBoundaries = FeatureCollection<Polygon, GeoJsonProperties>;
 
 export interface ParkingLotGeoJSONModules {

--- a/packages/shared/tests/dropdownUtils.test.ts
+++ b/packages/shared/tests/dropdownUtils.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { createChoice } from "../src/js/city-ui/dropdownUtils";
+
+test.describe("createChoice()", () => {
+  test("city and state", () => {
+    expect(createChoice("tempe-az", "Tempe, AZ")).toEqual({
+      value: "tempe-az",
+      label: "Tempe, AZ",
+      customProperties: { city: "Tempe", context: "AZ" },
+    });
+  });
+
+  test("city and descriptor", () => {
+    expect(createChoice("tempe-rail-station", "Tempe - rail station")).toEqual({
+      value: "tempe-rail-station",
+      label: "Tempe - rail station",
+      customProperties: { city: "Tempe", context: "rail station" },
+    });
+  });
+
+  test("only city", () => {
+    expect(createChoice("tempe", "Tempe")).toEqual({
+      value: "tempe",
+      label: "Tempe",
+      customProperties: { city: "Tempe", context: "" },
+    });
+  });
+});


### PR DESCRIPTION
Generalizes https://github.com/ParkingReformNetwork/parking-lot-map/pull/239 to the new CT map where the city names won't have states and will have descriptors like `- rail station`.

We need a new file for the dropdown pure functions to be able to test the code because `choices.js`'s import uses `window`, which isn't available in Playwright's node environment.