### PR TITLE
Use explicit null values in city-stats.json

### DIFF
--- a/packages/ct/data/city-stats.json
+++ b/packages/ct/data/city-stats.json
@@ -7,7 +7,8 @@
     "urbanizedAreaPopulation": "977,158",
     "parkingScore": "53",
     "reforms": "adopted",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Hartford_CT.html"
+    "url": "https://parkingreform.org/mandates-map/city_detail/Hartford_CT.html",
+    "contribution": null
   },
   "new-haven": {
     "name": "New Haven",
@@ -17,6 +18,7 @@
     "urbanizedAreaPopulation": "561,456",
     "parkingScore": null,
     "reforms": "adopted",
-    "url": "https://parkingreform.org/mandates-map/city_detail/NewHaven_CT.html"
+    "url": "https://parkingreform.org/mandates-map/city_detail/NewHaven_CT.html",
+    "contribution": null
   }
 }

--- a/packages/primary/data/city-stats.json
+++ b/packages/primary/data/city-stats.json
@@ -6,8 +6,9 @@
     "population": "99,233",
     "urbanizedAreaPopulation": "593,142",
     "parkingScore": "50",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Albany_NY.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Albany_NY.html",
+    "contribution": null
   },
   "albuquerque-nm": {
     "name": "Albuquerque, NM",
@@ -16,8 +17,9 @@
     "population": "564,559",
     "urbanizedAreaPopulation": "769,837",
     "parkingScore": "63",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Albuquerque_NM.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Albuquerque_NM.html",
+    "contribution": null
   },
   "allentown-pa": {
     "name": "Allentown, PA",
@@ -26,8 +28,9 @@
     "population": "125,858",
     "urbanizedAreaPopulation": "621,703",
     "parkingScore": "47",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Allentown_PA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Allentown_PA.html",
+    "contribution": null
   },
   "anaheim-ca": {
     "name": "Anaheim, CA",
@@ -36,8 +39,9 @@
     "population": "346,824",
     "urbanizedAreaPopulation": "12,237,376",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Anaheim_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Anaheim_CA.html",
+    "contribution": null
   },
   "anchorage-ak": {
     "name": "Anchorage, AK",
@@ -46,8 +50,9 @@
     "population": "291,247",
     "urbanizedAreaPopulation": "249,252",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Anchorage_AK.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Anchorage_AK.html",
+    "contribution": null
   },
   "arcata-ca": {
     "name": "Arcata, CA",
@@ -56,7 +61,7 @@
     "population": "18,857",
     "urbanizedAreaPopulation": "19,714",
     "parkingScore": null,
-    "reforms": "implemented",
+    "reforms": "adopted",
     "url": "https://parkingreform.org/mandates-map/city_detail/Arcata_CA.html",
     "contribution": "colin.fiske@gmail.com"
   },
@@ -67,8 +72,9 @@
     "population": "394,218",
     "urbanizedAreaPopulation": "5,732,354",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Arlington_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Arlington_TX.html",
+    "contribution": null
   },
   "atlanta-ga": {
     "name": "Atlanta, GA",
@@ -77,8 +83,9 @@
     "population": "498,715",
     "urbanizedAreaPopulation": "5,100,112",
     "parkingScore": "73",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Atlanta_GA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Atlanta_GA.html",
+    "contribution": null
   },
   "aurora-co": {
     "name": "Aurora, CO",
@@ -87,8 +94,9 @@
     "population": "386,261",
     "urbanizedAreaPopulation": "2,686,147",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Aurora_CO.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Aurora_CO.html",
+    "contribution": null
   },
   "austin-tx": {
     "name": "Austin, TX",
@@ -97,8 +105,9 @@
     "population": "959,549",
     "urbanizedAreaPopulation": "1,809,888",
     "parkingScore": "21",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Austin_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Austin_TX.html",
+    "contribution": null
   },
   "bakersfield-ca": {
     "name": "Bakersfield, CA",
@@ -107,8 +116,9 @@
     "population": "403,455",
     "urbanizedAreaPopulation": "570,235",
     "parkingScore": "40",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Bakersfield_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Bakersfield_CA.html",
+    "contribution": null
   },
   "baltimore-md": {
     "name": "Baltimore, MD",
@@ -117,8 +127,9 @@
     "population": "585,708",
     "urbanizedAreaPopulation": "2,212,038",
     "parkingScore": "42",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Baltimore_MD.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Baltimore_MD.html",
+    "contribution": null
   },
   "baton-rouge-la": {
     "name": "Baton Rouge, LA",
@@ -127,8 +138,9 @@
     "population": "226,916",
     "urbanizedAreaPopulation": "631,326",
     "parkingScore": "64",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/BatonRouge_LA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/BatonRouge_LA.html",
+    "contribution": null
   },
   "birmingham-al": {
     "name": "Birmingham, AL",
@@ -137,8 +149,9 @@
     "population": "200,733",
     "urbanizedAreaPopulation": "774,956",
     "parkingScore": "56",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Birmingham_AL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Birmingham_AL.html",
+    "contribution": null
   },
   "boston-ma": {
     "name": "Boston, MA",
@@ -147,8 +160,9 @@
     "population": "676,216",
     "urbanizedAreaPopulation": "4,382,009",
     "parkingScore": "29",
-    "reforms": "passed",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Boston_MA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Boston_MA.html",
+    "contribution": null
   },
   "buffalo-ny": {
     "name": "Buffalo, NY",
@@ -157,8 +171,9 @@
     "population": "278,349",
     "urbanizedAreaPopulation": "948,864",
     "parkingScore": "64",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Buffalo_NY.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Buffalo_NY.html",
+    "contribution": null
   },
   "charleston-sc": {
     "name": "Charleston, SC",
@@ -167,8 +182,9 @@
     "population": "150,288",
     "urbanizedAreaPopulation": "684,773",
     "parkingScore": "33",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Charleston_SC.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Charleston_SC.html",
+    "contribution": null
   },
   "charlotte-nc": {
     "name": "Charlotte, NC",
@@ -177,8 +193,9 @@
     "population": "874,541",
     "urbanizedAreaPopulation": "1,379,873",
     "parkingScore": "50",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Charlotte_NC.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Charlotte_NC.html",
+    "contribution": null
   },
   "chicago-il": {
     "name": "Chicago, IL",
@@ -187,8 +204,9 @@
     "population": "2,747,231",
     "urbanizedAreaPopulation": "8,671,746",
     "parkingScore": "15",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Chicago_IL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Chicago_IL.html",
+    "contribution": null
   },
   "cincinnati-oh": {
     "name": "Cincinnati, OH",
@@ -197,8 +215,9 @@
     "population": "309,317",
     "urbanizedAreaPopulation": "1,686,744",
     "parkingScore": "38",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Cincinnati_OH.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Cincinnati_OH.html",
+    "contribution": null
   },
   "cleveland-oh": {
     "name": "Cleveland, OH",
@@ -207,8 +226,9 @@
     "population": "373,091",
     "urbanizedAreaPopulation": "1,712,178",
     "parkingScore": "50",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Cleveland_OH.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Cleveland_OH.html",
+    "contribution": null
   },
   "colorado-springs-co": {
     "name": "Colorado Springs, CO",
@@ -217,8 +237,9 @@
     "population": "478,961",
     "urbanizedAreaPopulation": "632,494",
     "parkingScore": "26",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/ColoradoSprings_CO.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/ColoradoSprings_CO.html",
+    "contribution": null
   },
   "columbia-sc": {
     "name": "Columbia, SC",
@@ -227,8 +248,9 @@
     "population": "136,803",
     "urbanizedAreaPopulation": "590,407",
     "parkingScore": "78",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Columbia_SC.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Columbia_SC.html",
+    "contribution": null
   },
   "columbus-oh": {
     "name": "Columbus, OH",
@@ -237,8 +259,9 @@
     "population": "905,672",
     "urbanizedAreaPopulation": "1,567,254",
     "parkingScore": "53",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Columbus_OH.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Columbus_OH.html",
+    "contribution": null
   },
   "corpus-christi-tx": {
     "name": "Corpus Christi, TX",
@@ -247,8 +270,9 @@
     "population": "317,863",
     "urbanizedAreaPopulation": "339,066",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/CorpusChristi_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/CorpusChristi_TX.html",
+    "contribution": null
   },
   "dallas-tx": {
     "name": "Dallas, TX",
@@ -257,8 +281,9 @@
     "population": "1,304,442",
     "urbanizedAreaPopulation": "5,732,354",
     "parkingScore": "77",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Dallas_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Dallas_TX.html",
+    "contribution": null
   },
   "dayton-oh": {
     "name": "Dayton, OH",
@@ -267,8 +292,9 @@
     "population": "137,624",
     "urbanizedAreaPopulation": "674,046",
     "parkingScore": "50",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Dayton_OH.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Dayton_OH.html",
+    "contribution": null
   },
   "denver-co": {
     "name": "Denver, CO",
@@ -277,8 +303,9 @@
     "population": "715,522",
     "urbanizedAreaPopulation": "2,686,147",
     "parkingScore": "48",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Denver_CO.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Denver_CO.html",
+    "contribution": null
   },
   "des-moines-ia": {
     "name": "Des Moines, IA",
@@ -287,8 +314,9 @@
     "population": "214,125",
     "urbanizedAreaPopulation": "542,486",
     "parkingScore": "38",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/DesMoines_IA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/DesMoines_IA.html",
+    "contribution": null
   },
   "detroit-mi": {
     "name": "Detroit, MI",
@@ -297,8 +325,9 @@
     "population": "639,614",
     "urbanizedAreaPopulation": "3,776,890",
     "parkingScore": "100",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Detroit_MI.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Detroit_MI.html",
+    "contribution": null
   },
   "el-paso-tx": {
     "name": "El Paso, TX",
@@ -307,8 +336,9 @@
     "population": "678,815",
     "urbanizedAreaPopulation": "854,584",
     "parkingScore": "42",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/ElPaso_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/ElPaso_TX.html",
+    "contribution": null
   },
   "fort-myers-fl": {
     "name": "Fort Myers, FL",
@@ -317,8 +347,9 @@
     "population": "86,401",
     "urbanizedAreaPopulation": "599,242",
     "parkingScore": "57",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/FortMyers_FL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/FortMyers_FL.html",
+    "contribution": null
   },
   "fort-worth-tx": {
     "name": "Fort Worth, TX",
@@ -327,8 +358,9 @@
     "population": "918,377",
     "urbanizedAreaPopulation": "5,732,354",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/FortWorth_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/FortWorth_TX.html",
+    "contribution": null
   },
   "fresno-ca": {
     "name": "Fresno, CA",
@@ -337,8 +369,9 @@
     "population": "542,107",
     "urbanizedAreaPopulation": "717,589",
     "parkingScore": "65",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Fresno_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Fresno_CA.html",
+    "contribution": null
   },
   "grand-rapids-mi": {
     "name": "Grand Rapids, MI",
@@ -347,8 +380,9 @@
     "population": "198,917",
     "urbanizedAreaPopulation": "605,666",
     "parkingScore": "50",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/GrandRapids_MI.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/GrandRapids_MI.html",
+    "contribution": null
   },
   "greensboro-nc": {
     "name": "Greensboro, NC",
@@ -357,8 +391,9 @@
     "population": "299,035",
     "urbanizedAreaPopulation": "338,928",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Greensboro_NC.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Greensboro_NC.html",
+    "contribution": null
   },
   "harrisburg-pa": {
     "name": "Harrisburg, PA",
@@ -367,8 +402,9 @@
     "population": "50,088",
     "urbanizedAreaPopulation": "490,859",
     "parkingScore": "53",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Harrisburg_PA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Harrisburg_PA.html",
+    "contribution": null
   },
   "hartford-ct": {
     "name": "Hartford, CT",
@@ -377,8 +413,9 @@
     "population": "121,054",
     "urbanizedAreaPopulation": "977,158",
     "parkingScore": "53",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Hartford_CT.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Hartford_CT.html",
+    "contribution": null
   },
   "henderson-nv": {
     "name": "Henderson, NV",
@@ -387,8 +424,9 @@
     "population": "317,610",
     "urbanizedAreaPopulation": "2,196,623",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Henderson_NV.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Henderson_NV.html",
+    "contribution": null
   },
   "honolulu-hi": {
     "name": "Honolulu, HI",
@@ -397,8 +435,9 @@
     "population": "350,964",
     "urbanizedAreaPopulation": "853,252",
     "parkingScore": "21",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Honolulu_HI.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Honolulu_HI.html",
+    "contribution": null
   },
   "houston-tx": {
     "name": "Houston, TX",
@@ -407,8 +446,9 @@
     "population": "2,302,792",
     "urbanizedAreaPopulation": "5,853,575",
     "parkingScore": "73",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Houston_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Houston_TX.html",
+    "contribution": null
   },
   "indianapolis-in": {
     "name": "Indianapolis, IN",
@@ -417,8 +457,9 @@
     "population": "887,752",
     "urbanizedAreaPopulation": "1,699,881",
     "parkingScore": "51",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Indianapolis_IN.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Indianapolis_IN.html",
+    "contribution": null
   },
   "jacksonville-fl": {
     "name": "Jacksonville, FL",
@@ -427,8 +468,9 @@
     "population": "949,611",
     "urbanizedAreaPopulation": "1,247,374",
     "parkingScore": "48",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Jacksonville_FL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Jacksonville_FL.html",
+    "contribution": null
   },
   "jersey-city-nj": {
     "name": "Jersey City, NJ",
@@ -437,8 +479,9 @@
     "population": "292,449",
     "urbanizedAreaPopulation": "19,426,449",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/JerseyCity_NJ.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/JerseyCity_NJ.html",
+    "contribution": null
   },
   "kansas-city-mo": {
     "name": "Kansas City, MO",
@@ -447,8 +490,9 @@
     "population": "507,969",
     "urbanizedAreaPopulation": "1,674,218",
     "parkingScore": "64",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/KansasCity_MO.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/KansasCity_MO.html",
+    "contribution": null
   },
   "knoxville-tn": {
     "name": "Knoxville, TN",
@@ -457,8 +501,9 @@
     "population": "190,728",
     "urbanizedAreaPopulation": "597,257",
     "parkingScore": "48",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Knoxville_TN.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Knoxville_TN.html",
+    "contribution": null
   },
   "las-vegas-nv": {
     "name": "Las Vegas, NV",
@@ -467,8 +512,9 @@
     "population": "641,825",
     "urbanizedAreaPopulation": "2,196,623",
     "parkingScore": "93",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/LasVegas_NV.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/LasVegas_NV.html",
+    "contribution": null
   },
   "lexington-ky": {
     "name": "Lexington, KY",
@@ -477,8 +523,9 @@
     "population": "322,570",
     "urbanizedAreaPopulation": "315,631",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Lexington_KY.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Lexington_KY.html",
+    "contribution": null
   },
   "lincoln-ne": {
     "name": "Lincoln, NE",
@@ -487,8 +534,9 @@
     "population": "291,082",
     "urbanizedAreaPopulation": "291,217",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Lincoln_NE.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Lincoln_NE.html",
+    "contribution": null
   },
   "little-rock-ar": {
     "name": "Little Rock, AR",
@@ -497,8 +545,9 @@
     "population": "202,562",
     "urbanizedAreaPopulation": "461,864",
     "parkingScore": "65",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/LittleRock_AR.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/LittleRock_AR.html",
+    "contribution": null
   },
   "long-beach-ca": {
     "name": "Long Beach, CA",
@@ -507,8 +556,9 @@
     "population": "466,302",
     "urbanizedAreaPopulation": "12,237,376",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/LongBeach_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/LongBeach_CA.html",
+    "contribution": null
   },
   "los-angeles-ca": {
     "name": "Los Angeles, CA",
@@ -517,8 +567,9 @@
     "population": "3,893,986",
     "urbanizedAreaPopulation": "12,237,376",
     "parkingScore": "63",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/LosAngeles_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/LosAngeles_CA.html",
+    "contribution": null
   },
   "louisville-ky": {
     "name": "Louisville, KY",
@@ -527,8 +578,9 @@
     "population": "632,689",
     "urbanizedAreaPopulation": "974,397",
     "parkingScore": "66",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Louisville_KY.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Louisville_KY.html",
+    "contribution": null
   },
   "madison-wi": {
     "name": "Madison, WI",
@@ -537,8 +589,9 @@
     "population": "269,769",
     "urbanizedAreaPopulation": "450,305",
     "parkingScore": "14",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Madison_WI.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Madison_WI.html",
+    "contribution": null
   },
   "mcallen-tx": {
     "name": "McAllen, TX",
@@ -547,8 +600,9 @@
     "population": "142,195",
     "urbanizedAreaPopulation": "779,553",
     "parkingScore": "46",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/McAllen_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/McAllen_TX.html",
+    "contribution": null
   },
   "melbourne-fl": {
     "name": "Melbourne, FL",
@@ -557,8 +611,9 @@
     "population": "84,703",
     "urbanizedAreaPopulation": "510,675",
     "parkingScore": "68",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Melbourne_FL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Melbourne_FL.html",
+    "contribution": null
   },
   "memphis-tn": {
     "name": "Memphis, TN",
@@ -567,8 +622,9 @@
     "population": "633,104",
     "urbanizedAreaPopulation": "1,056,190",
     "parkingScore": "53",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Memphis_TN.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Memphis_TN.html",
+    "contribution": null
   },
   "mesa-az": {
     "name": "Mesa, AZ",
@@ -577,8 +633,9 @@
     "population": "504,500",
     "urbanizedAreaPopulation": "3,976,313",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Mesa_AZ.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Mesa_AZ.html",
+    "contribution": null
   },
   "miami-fl": {
     "name": "Miami, FL",
@@ -588,7 +645,8 @@
     "urbanizedAreaPopulation": "6,077,522",
     "parkingScore": "50",
     "reforms": "repealed",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Miami_FL.html"
+    "url": "https://parkingreform.org/mandates-map/city_detail/Miami_FL.html",
+    "contribution": null
   },
   "milwaukee-wi": {
     "name": "Milwaukee, WI",
@@ -597,8 +655,9 @@
     "population": "577,222",
     "urbanizedAreaPopulation": "1,306,795",
     "parkingScore": "32",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Milwaukee_WI.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Milwaukee_WI.html",
+    "contribution": null
   },
   "minneapolis-mn": {
     "name": "Minneapolis, MN",
@@ -607,8 +666,9 @@
     "population": "428,403",
     "urbanizedAreaPopulation": "2,914,866",
     "parkingScore": "55",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Minneapolis_MN.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Minneapolis_MN.html",
+    "contribution": null
   },
   "nashville-tn": {
     "name": "Nashville, TN",
@@ -617,8 +677,9 @@
     "population": "689,504",
     "urbanizedAreaPopulation": "1,158,642",
     "parkingScore": "44",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Nashville_TN.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Nashville_TN.html",
+    "contribution": null
   },
   "new-haven-ct": {
     "name": "New Haven, CT",
@@ -627,8 +688,9 @@
     "population": "134,023",
     "urbanizedAreaPopulation": "561,456",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/NewHaven_CT.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/NewHaven_CT.html",
+    "contribution": null
   },
   "new-orleans-la": {
     "name": "New Orleans, LA",
@@ -637,8 +699,9 @@
     "population": "383,997",
     "urbanizedAreaPopulation": "963,212",
     "parkingScore": "38",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/NewOrleans_LA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/NewOrleans_LA.html",
+    "contribution": null
   },
   "new-york-ny": {
     "name": "New York, NY",
@@ -647,8 +710,9 @@
     "population": "8,804,190",
     "urbanizedAreaPopulation": "19,426,449",
     "parkingScore": "1",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/NewYorkCIty_NY.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/NewYorkCIty_NY.html",
+    "contribution": null
   },
   "newark-nj": {
     "name": "Newark, NJ",
@@ -657,8 +721,9 @@
     "population": "311,549",
     "urbanizedAreaPopulation": "19,426,449",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Newark_NJ.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Newark_NJ.html",
+    "contribution": null
   },
   "norfolk-va": {
     "name": "Norfolk, VA",
@@ -667,8 +732,9 @@
     "population": "238,005",
     "urbanizedAreaPopulation": "1,451,578",
     "parkingScore": "47",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Norfolk_VA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Norfolk_VA.html",
+    "contribution": null
   },
   "oakland-ca": {
     "name": "Oakland, CA",
@@ -677,8 +743,9 @@
     "population": "439,349",
     "urbanizedAreaPopulation": "3,515,933",
     "parkingScore": "39",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Oakland_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Oakland_CA.html",
+    "contribution": null
   },
   "oklahoma-city-ok": {
     "name": "Oklahoma City, OK",
@@ -687,8 +754,9 @@
     "population": "681,054",
     "urbanizedAreaPopulation": "982,276",
     "parkingScore": "47",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/OklahomaCity_OK.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/OklahomaCity_OK.html",
+    "contribution": null
   },
   "omaha-ne": {
     "name": "Omaha, NE",
@@ -697,8 +765,9 @@
     "population": "486,051",
     "urbanizedAreaPopulation": "819,508",
     "parkingScore": "34",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Omaha_NE.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Omaha_NE.html",
+    "contribution": null
   },
   "orlando-fl": {
     "name": "Orlando, FL",
@@ -707,8 +776,9 @@
     "population": "307,573",
     "urbanizedAreaPopulation": "1,853,896",
     "parkingScore": "69",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Orlando_FL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Orlando_FL.html",
+    "contribution": null
   },
   "philadelphia-pa": {
     "name": "Philadelphia, PA",
@@ -717,8 +787,9 @@
     "population": "1,603,797",
     "urbanizedAreaPopulation": "5,696,125",
     "parkingScore": "23",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Philadelphia_PA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Philadelphia_PA.html",
+    "contribution": null
   },
   "phoenix-az": {
     "name": "Phoenix, AZ",
@@ -727,8 +798,9 @@
     "population": "1,607,739",
     "urbanizedAreaPopulation": "3,976,313",
     "parkingScore": "77",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Phoenix_AZ.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Phoenix_AZ.html",
+    "contribution": null
   },
   "pittsburgh-pa": {
     "name": "Pittsburgh, PA",
@@ -737,8 +809,9 @@
     "population": "302,971",
     "urbanizedAreaPopulation": "1,745,039",
     "parkingScore": "17",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Pittsburgh_PA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Pittsburgh_PA.html",
+    "contribution": null
   },
   "portland-or": {
     "name": "Portland, OR",
@@ -747,8 +820,9 @@
     "population": "652,089",
     "urbanizedAreaPopulation": "2,104,238",
     "parkingScore": "4",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Portland_OR.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Portland_OR.html",
+    "contribution": null
   },
   "providence-ri": {
     "name": "Providence, RI",
@@ -757,8 +831,9 @@
     "population": "190,934",
     "urbanizedAreaPopulation": "1,285,806",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Providence_RI.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Providence_RI.html",
+    "contribution": null
   },
   "raleigh-nc": {
     "name": "Raleigh, NC",
@@ -767,8 +842,9 @@
     "population": "467,665",
     "urbanizedAreaPopulation": "1,106,646",
     "parkingScore": "57",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Raleigh_NC.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Raleigh_NC.html",
+    "contribution": null
   },
   "richmond-va": {
     "name": "Richmond, VA",
@@ -777,8 +853,9 @@
     "population": "226,610",
     "urbanizedAreaPopulation": "1,059,150",
     "parkingScore": "48",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Richmond_VA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Richmond_VA.html",
+    "contribution": null
   },
   "riverside-ca": {
     "name": "Riverside, CA",
@@ -787,8 +864,9 @@
     "population": "317,610",
     "urbanizedAreaPopulation": "2,276,703",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Riverside_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Riverside_CA.html",
+    "contribution": null
   },
   "rochester-ny": {
     "name": "Rochester, NY",
@@ -797,8 +875,9 @@
     "population": "211,328",
     "urbanizedAreaPopulation": "704,327",
     "parkingScore": "48",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Rochester_NY.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Rochester_NY.html",
+    "contribution": null
   },
   "sacramento-ca": {
     "name": "Sacramento, CA",
@@ -807,8 +886,9 @@
     "population": "522,754",
     "urbanizedAreaPopulation": "1,946,618",
     "parkingScore": "25",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Sacramento_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Sacramento_CA.html",
+    "contribution": null
   },
   "saint-paul-mn": {
     "name": "Saint Paul, MN",
@@ -817,8 +897,9 @@
     "population": "311,527",
     "urbanizedAreaPopulation": "2,914,866",
     "parkingScore": "52",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/St.Paul_MN.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/St.Paul_MN.html",
+    "contribution": null
   },
   "salt-lake-city-ut": {
     "name": "Salt Lake City, UT",
@@ -827,8 +908,9 @@
     "population": "199,723",
     "urbanizedAreaPopulation": "1,178,533",
     "parkingScore": "60",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SaltLakeCity_UT.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SaltLakeCity_UT.html",
+    "contribution": null
   },
   "san-antonio-tx": {
     "name": "San Antonio, TX",
@@ -837,8 +919,9 @@
     "population": "1,434,270",
     "urbanizedAreaPopulation": "1,992,689",
     "parkingScore": "86",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SanAntonio_TX.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SanAntonio_TX.html",
+    "contribution": null
   },
   "san-bernardino-ca": {
     "name": "San Bernardino, CA",
@@ -847,8 +930,9 @@
     "population": "222,101",
     "urbanizedAreaPopulation": "2,276,703",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SanBernardino_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SanBernardino_CA.html",
+    "contribution": null
   },
   "san-diego-ca": {
     "name": "San Diego, CA",
@@ -857,8 +941,9 @@
     "population": "1,385,922",
     "urbanizedAreaPopulation": "3,070,300",
     "parkingScore": "38",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SanDiego_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SanDiego_CA.html",
+    "contribution": null
   },
   "san-francisco-ca": {
     "name": "San Francisco, CA",
@@ -867,8 +952,9 @@
     "population": "873,965",
     "urbanizedAreaPopulation": "3,515,933",
     "parkingScore": "5",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SanFrancisco_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SanFrancisco_CA.html",
+    "contribution": null
   },
   "san-jose-ca": {
     "name": "San Jose, CA",
@@ -877,8 +963,9 @@
     "population": "1,014,545",
     "urbanizedAreaPopulation": "1,837,446",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SanJose_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SanJose_CA.html",
+    "contribution": null
   },
   "san-juan-pr": {
     "name": "San Juan, PR",
@@ -887,8 +974,9 @@
     "population": "342,259",
     "urbanizedAreaPopulation": "1,814,587",
     "parkingScore": "100",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SanJuan_PR.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SanJuan_PR.html",
+    "contribution": null
   },
   "santa-ana-ca": {
     "name": "Santa Ana, CA",
@@ -897,8 +985,9 @@
     "population": "310,227",
     "urbanizedAreaPopulation": "12,237,376",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SantaAna_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SantaAna_CA.html",
+    "contribution": null
   },
   "santa-barbara-ca": {
     "name": "Santa Barbara, CA",
@@ -907,8 +996,9 @@
     "population": "88,665",
     "urbanizedAreaPopulation": "199,023",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/SantaBarbara_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/SantaBarbara_CA.html",
+    "contribution": null
   },
   "sarasota-fl": {
     "name": "Sarasota, FL",
@@ -917,8 +1007,9 @@
     "population": "54,840",
     "urbanizedAreaPopulation": "779,075",
     "parkingScore": "52",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Sarasota_FL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Sarasota_FL.html",
+    "contribution": null
   },
   "seattle-wa": {
     "name": "Seattle, WA",
@@ -927,8 +1018,9 @@
     "population": "735,157",
     "urbanizedAreaPopulation": "3,544,011",
     "parkingScore": "37",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Seattle_WA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Seattle_WA.html",
+    "contribution": null
   },
   "st-louis-mo": {
     "name": "St. Louis, MO",
@@ -937,8 +1029,9 @@
     "population": "301,578",
     "urbanizedAreaPopulation": "2,156,323",
     "parkingScore": "50",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/St.Louis_MO.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/St.Louis_MO.html",
+    "contribution": null
   },
   "st-petersburg-fl": {
     "name": "St. Petersburg, FL",
@@ -947,8 +1040,9 @@
     "population": "258,308",
     "urbanizedAreaPopulation": "2,783,045",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/St.Petersburg_FL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/St.Petersburg_FL.html",
+    "contribution": null
   },
   "stockton-ca": {
     "name": "Stockton, CA",
@@ -957,8 +1051,9 @@
     "population": "320,804",
     "urbanizedAreaPopulation": "414,847",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Stockton_CA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Stockton_CA.html",
+    "contribution": null
   },
   "tampa-fl": {
     "name": "Tampa, FL",
@@ -967,8 +1062,9 @@
     "population": "382,769",
     "urbanizedAreaPopulation": "2,783,045",
     "parkingScore": "85",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Tampa_FL.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Tampa_FL.html",
+    "contribution": null
   },
   "toledo-oh": {
     "name": "Toledo, OH",
@@ -977,8 +1073,9 @@
     "population": "270,880",
     "urbanizedAreaPopulation": "497,952",
     "parkingScore": "45",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Toledo_OH.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Toledo_OH.html",
+    "contribution": null
   },
   "tucson-az": {
     "name": "Tucson, AZ",
@@ -987,8 +1084,9 @@
     "population": "542,629",
     "urbanizedAreaPopulation": "875,441",
     "parkingScore": "29",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Tucson_AZ.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Tucson_AZ.html",
+    "contribution": null
   },
   "tulsa-ok": {
     "name": "Tulsa, OK",
@@ -997,8 +1095,9 @@
     "population": "413,066",
     "urbanizedAreaPopulation": "722,810",
     "parkingScore": "59",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Tulsa_OK.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Tulsa_OK.html",
+    "contribution": null
   },
   "virginia-beach-va": {
     "name": "Virginia Beach, VA",
@@ -1007,8 +1106,9 @@
     "population": "459,470",
     "urbanizedAreaPopulation": "2,196,623",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/VirginiaBeach_VA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/VirginiaBeach_VA.html",
+    "contribution": null
   },
   "washington-dc": {
     "name": "Washington, DC",
@@ -1017,8 +1117,9 @@
     "population": "689,545",
     "urbanizedAreaPopulation": "5,174,759",
     "parkingScore": "7",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/WashingtonDC_DC.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/WashingtonDC_DC.html",
+    "contribution": null
   },
   "wichita-ks": {
     "name": "Wichita, KS",
@@ -1027,8 +1128,9 @@
     "population": "397,532",
     "urbanizedAreaPopulation": "500,231",
     "parkingScore": "69",
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Wichita_KS.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Wichita_KS.html",
+    "contribution": null
   },
   "worcester-ma": {
     "name": "Worcester, MA",
@@ -1037,7 +1139,8 @@
     "population": "206,518",
     "urbanizedAreaPopulation": "482,085",
     "parkingScore": null,
-    "reforms": "implemented",
-    "url": "https://parkingreform.org/mandates-map/city_detail/Worcester_MA.html"
+    "reforms": "adopted",
+    "url": "https://parkingreform.org/mandates-map/city_detail/Worcester_MA.html",
+    "contribution": null
   }
 }

--- a/packages/primary/tests/dropdownGroups.test.ts
+++ b/packages/primary/tests/dropdownGroups.test.ts
@@ -9,12 +9,13 @@ test("createDropdownGroups", () => {
     urbanizedAreaPopulation: "",
     parkingScore: null,
     reforms: "",
-    url: "",
+    url: null,
   };
   const input = {
     "city1-ny": {
       ...common,
       name: "City 1, NY",
+      contribution: null,
     },
     "city2-ny": {
       ...common,

--- a/packages/scripts/src/add-city.ts
+++ b/packages/scripts/src/add-city.ts
@@ -19,6 +19,8 @@ const addScoreCard = async (
       "FILL ME IN, e.g. 53. If not relevant, remove the quotes and set to null",
     reforms: "FILL ME IN, e.g. No Reforms or Implemented",
     url: "FILL ME IN. If not relevant, remove the quotes and set to null",
+    contribution:
+      "FILL ME IN with the email of the contributor. If it's an official map, remove the quotes and set to null",
   };
 
   const originalFilePath = "packages/primary/data/city-stats.json";

--- a/packages/shared/src/js/city-ui/scorecard.ts
+++ b/packages/shared/src/js/city-ui/scorecard.ts
@@ -33,7 +33,7 @@ function generateScorecard(stats: CityStats): string {
   }
   listEntries.push(reformsLine);
 
-  if ("contribution" in stats) {
+  if (stats.contribution) {
     listEntries.push(
       `<a href="mailto:${stats.contribution}">Email data maintainer</a>`,
     );

--- a/packages/shared/src/js/model/types.ts
+++ b/packages/shared/src/js/model/types.ts
@@ -19,8 +19,8 @@ export interface CityStats {
   urbanizedAreaPopulation: string;
   parkingScore: string | null;
   reforms: string;
-  url?: string;
-  contribution?: string;
+  url: string | null;
+  contribution: string | null;
 }
 
 export type CityStatsCollection = Record<CityId, CityStats>;


### PR DESCRIPTION
This is more maintainable. The data set is so small that I'm not worried about the marginal size in storage.