### PR TITLE
Use more conventional TS style in packages/scripts

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,6 +17,9 @@ overrides:
   - files: ["**/*.test.ts", "**/playwright.config.js"]
     rules:
       "import/no-extraneous-dependencies": "off"
+  - files: ["packages/scripts/**/*.ts"]
+    rules:
+      "no-console": "off"
 
 rules:
   no-unexpected-multiline: off

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -9,8 +9,7 @@
     "update-lots": "tsx src/update-lots.ts"
   },
   "dependencies": {
-    "@prn-parking-lots/shared": "workspace:*",
-    "ts-results": "^3.3.0"
+    "@prn-parking-lots/shared": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/packages/scripts/src/update-city-boundaries.ts
+++ b/packages/scripts/src/update-city-boundaries.ts
@@ -1,28 +1,23 @@
 import { determineArgs, updateCoordinates } from "./base.ts";
 
-const main = async (): Promise<void> => {
+async function main(): Promise<void> {
   const { cityId } = determineArgs(
     "update-city-boundaries",
     process.argv.slice(2),
-  )
-    .mapErr((err) => new Error(`Argument error: ${err}`))
-    .unwrap();
-  const value = (
-    await updateCoordinates(
-      "update-city-boundaries",
-      cityId,
-      false,
-      "packages/primary/data/city-boundaries.geojson",
-      "city-update.geojson",
-    )
-  ).unwrap();
+  );
+  await updateCoordinates(
+    "update-city-boundaries",
+    cityId,
+    false,
+    "packages/primary/data/city-boundaries.geojson",
+    "city-update.geojson",
+  );
 
-  /* eslint-disable-next-line no-console */
   console.log(
-    `${value} Now, run 'npm run fmt'. Then, 'npm start' and
+    `File updatad! Now, run 'pnpm fmt'. Then, start the server and
       see if the site is what you expect.
     `,
   );
-};
+}
 
 main();

--- a/packages/scripts/src/update-lots.ts
+++ b/packages/scripts/src/update-lots.ts
@@ -1,24 +1,19 @@
 import { determineArgs, updateParkingLots } from "./base.ts";
 
-const main = async (): Promise<void> => {
-  const { cityId } = determineArgs("update-lots", process.argv.slice(2))
-    .mapErr((err) => new Error(`Argument error: ${err}`))
-    .unwrap();
-  const value = (
-    await updateParkingLots(
-      cityId,
-      false,
-      "parking-lots-update.geojson",
-      `packages/primary/data/parking-lots/${cityId}.geojson`,
-    )
-  ).unwrap();
+async function main(): Promise<void> {
+  const { cityId } = determineArgs("update-lots", process.argv.slice(2));
+  await updateParkingLots(
+    cityId,
+    false,
+    "parking-lots-update.geojson",
+    `packages/primary/data/parking-lots/${cityId}.geojson`,
+  );
 
-  /* eslint-disable-next-line no-console */
   console.log(
-    `${value} Now, run 'npm run fmt'. Then, 'npm start' and
+    `File updated! Now, run 'pnpm fmt'. Then, start the server and
       see if the site is what you expect.
     `,
   );
-};
+}
 
 main();

--- a/packages/scripts/tests/base.test.ts
+++ b/packages/scripts/tests/base.test.ts
@@ -13,7 +13,7 @@ import {
 
 test.describe("determineArgs()", () => {
   test("returns the city name and ID", () => {
-    expect(determineArgs("my-script", ["My City"]).unwrap()).toEqual({
+    expect(determineArgs("my-script", ["My City"])).toEqual({
       cityName: "My City",
       cityId: "my-city",
     });
@@ -21,7 +21,7 @@ test.describe("determineArgs()", () => {
 
   [[], ["My City", "--bad"], ["My City", "AZ"]].forEach((args, index) => {
     test(`${index}) requires exactly 1 argument`, () => {
-      expect(() => determineArgs("my-script", args).unwrap()).toThrow(
+      expect(() => determineArgs("my-script", args)).toThrow(
         /exactly one argument/,
       );
     });
@@ -47,14 +47,13 @@ test.describe("updateCoordinates()", () => {
     const updateFilePath = validUpdateFilePath;
 
     const cityId = "shoup-ville-az";
-    const result = await updateCoordinates(
+    await updateCoordinates(
       "my-script",
       cityId,
       false,
       originalFilePath,
       updateFilePath,
     );
-    expect(result.ok).toBe(true);
 
     const rawUpdateData = await fs.readFile(updateFilePath, "utf8");
     const updateData = JSON.parse(rawUpdateData);
@@ -73,14 +72,13 @@ test.describe("updateCoordinates()", () => {
     const updateFilePath = validUpdateFilePath;
 
     const cityId = "parking-reform-now";
-    const result = await updateCoordinates(
+    await updateCoordinates(
       "my-script",
       cityId,
       true,
       originalFilePath,
       updateFilePath,
     );
-    expect(result.ok).toBe(true);
 
     const rawUpdatedData = await fs.readFile(updateFilePath, "utf8");
     const updatedData = JSON.parse(rawUpdatedData);
@@ -105,60 +103,66 @@ test.describe("updateCoordinates()", () => {
   });
 
   test("errors if city cannot be found in the original data and add not set", async () => {
-    const result = await updateCoordinates(
-      "my-script",
-      "bad-city",
-      false,
-      originalFilePath,
-      validUpdateFilePath,
-    );
-    expect(() => result.unwrap()).toThrow(/To add a new city,/);
+    await expect(
+      async () =>
+        await updateCoordinates(
+          "my-script",
+          "bad-city",
+          false,
+          originalFilePath,
+          validUpdateFilePath,
+        ),
+    ).rejects.toThrow(/To add a new city,/);
   });
 
   test("validates the update file has exactly one `feature`", async () => {
-    let result = await updateCoordinates(
-      "my-script",
-      "shoup-ville-az",
-      false,
-      originalFilePath,
-      "tests/data/too-many-updates.geojson",
-    );
-    expect(() => result.unwrap()).toThrow(
-      /expects exactly one entry in `features`/,
-    );
+    await expect(
+      async () =>
+        await updateCoordinates(
+          "my-script",
+          "shoup-ville-az",
+          false,
+          originalFilePath,
+          "tests/data/too-many-updates.geojson",
+        ),
+    ).rejects.toThrow(/expects exactly one entry in `features`/);
 
-    result = await updateCoordinates(
-      "my-script",
-      "shoup-ville-az",
-      false,
-      originalFilePath,
-      "tests/data/empty-update.geojson",
-    );
-    expect(() => result.unwrap()).toThrow(
-      /expects exactly one entry in `features`/,
-    );
+    await expect(
+      async () =>
+        await updateCoordinates(
+          "my-script",
+          "shoup-ville-az",
+          false,
+          originalFilePath,
+          "tests/data/empty-update.geojson",
+        ),
+    ).rejects.toThrow(/expects exactly one entry in `features`/);
   });
 
   test("errors gracefully if update file not found", async () => {
-    const result = await updateCoordinates(
-      "my-script",
-      "shoup-ville-az",
-      false,
-      originalFilePath,
-      "tests/data/does-not-exist",
-    );
-    expect(() => result.unwrap()).toThrow(/tests\/data\/does-not-exist/);
+    await expect(
+      async () =>
+        await updateCoordinates(
+          "my-script",
+          "shoup-ville-az",
+          false,
+          originalFilePath,
+          "tests/data/does-not-exist",
+        ),
+    ).rejects.toThrow(/tests\/data\/does-not-exist/);
   });
 
   test("errors gracefully if original data file not found", async () => {
-    const result = await updateCoordinates(
-      "my-script",
-      "shoup-ville-az",
-      false,
-      "tests/data/does-not-exist",
-      validUpdateFilePath,
-    );
-    expect(() => result.unwrap()).toThrow(/tests\/data\/does-not-exist/);
+    await expect(
+      async () =>
+        await updateCoordinates(
+          "my-script",
+          "shoup-ville-az",
+          false,
+          "tests/data/does-not-exist",
+          validUpdateFilePath,
+        ),
+    ).rejects.toThrow(/tests\/data\/does-not-exist/);
   });
 });
 
@@ -195,32 +199,16 @@ test.describe("updateParkingLots()", () => {
 
   test("adds a new city", async () => {
     const cityId = "parking-reform-now";
-    const result = await updateParkingLots(
-      cityId,
-      true,
-      parkingLotData,
-      addDataPath,
-    );
-    expect(result.ok).toBe(true);
-
+    await updateParkingLots(cityId, true, parkingLotData, addDataPath);
     await expectUpdatedFile(cityId, addDataPath);
-
     await fs.rm(addDataPath);
   });
 
   test("update city lots", async () => {
     const existingDataPath = "tests/data/existing-lot-data.geojson";
     const existingData = await fs.readFile(existingDataPath);
-
     const cityId = "parking-reform-now";
-    const result = await updateParkingLots(
-      cityId,
-      true,
-      parkingLotData,
-      existingDataPath,
-    );
-    expect(result.ok).toBe(true);
-
+    await updateParkingLots(cityId, true, parkingLotData, existingDataPath);
     await expectUpdatedFile(cityId, existingDataPath);
     await fs.writeFile(existingDataPath, existingData);
   });

--- a/packages/scripts/tests/base.test.ts
+++ b/packages/scripts/tests/base.test.ts
@@ -103,65 +103,60 @@ test.describe("updateCoordinates()", () => {
   });
 
   test("errors if city cannot be found in the original data and add not set", async () => {
-    await expect(
-      async () =>
-        await updateCoordinates(
-          "my-script",
-          "bad-city",
-          false,
-          originalFilePath,
-          validUpdateFilePath,
-        ),
+    await expect(async () =>
+      updateCoordinates(
+        "my-script",
+        "bad-city",
+        false,
+        originalFilePath,
+        validUpdateFilePath,
+      ),
     ).rejects.toThrow(/To add a new city,/);
   });
 
   test("validates the update file has exactly one `feature`", async () => {
-    await expect(
-      async () =>
-        await updateCoordinates(
-          "my-script",
-          "shoup-ville-az",
-          false,
-          originalFilePath,
-          "tests/data/too-many-updates.geojson",
-        ),
+    await expect(async () =>
+      updateCoordinates(
+        "my-script",
+        "shoup-ville-az",
+        false,
+        originalFilePath,
+        "tests/data/too-many-updates.geojson",
+      ),
     ).rejects.toThrow(/expects exactly one entry in `features`/);
 
-    await expect(
-      async () =>
-        await updateCoordinates(
-          "my-script",
-          "shoup-ville-az",
-          false,
-          originalFilePath,
-          "tests/data/empty-update.geojson",
-        ),
+    await expect(async () =>
+      updateCoordinates(
+        "my-script",
+        "shoup-ville-az",
+        false,
+        originalFilePath,
+        "tests/data/empty-update.geojson",
+      ),
     ).rejects.toThrow(/expects exactly one entry in `features`/);
   });
 
   test("errors gracefully if update file not found", async () => {
-    await expect(
-      async () =>
-        await updateCoordinates(
-          "my-script",
-          "shoup-ville-az",
-          false,
-          originalFilePath,
-          "tests/data/does-not-exist",
-        ),
+    await expect(async () =>
+      updateCoordinates(
+        "my-script",
+        "shoup-ville-az",
+        false,
+        originalFilePath,
+        "tests/data/does-not-exist",
+      ),
     ).rejects.toThrow(/tests\/data\/does-not-exist/);
   });
 
   test("errors gracefully if original data file not found", async () => {
-    await expect(
-      async () =>
-        await updateCoordinates(
-          "my-script",
-          "shoup-ville-az",
-          false,
-          "tests/data/does-not-exist",
-          validUpdateFilePath,
-        ),
+    await expect(async () =>
+      updateCoordinates(
+        "my-script",
+        "shoup-ville-az",
+        false,
+        "tests/data/does-not-exist",
+        validUpdateFilePath,
+      ),
     ).rejects.toThrow(/tests\/data\/does-not-exist/);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,9 +103,6 @@ importers:
       "@prn-parking-lots/shared":
         specifier: workspace:*
         version: link:../shared
-      ts-results:
-        specifier: ^3.3.0
-        version: 3.3.0
     devDependencies:
       tsx:
         specifier: ^4.19.2
@@ -3584,12 +3581,6 @@ packages:
     peerDependencies:
       typescript: ">=4.8.4"
 
-  ts-results@3.3.0:
-    resolution:
-      {
-        integrity: sha512-FWqxGX2NHp5oCyaMd96o2y2uMQmSu8Dey6kvyuFdRJ2AzfmWo3kWa4UsPlCGlfQ/qu03m09ZZtppMoY8EMHuiA==,
-      }
-
   tsconfig-paths@3.15.0:
     resolution:
       {
@@ -6185,8 +6176,6 @@ snapshots:
   ts-api-utils@2.0.0(typescript@5.7.3):
     dependencies:
       typescript: 5.7.3
-
-  ts-results@3.3.0: {}
 
   tsconfig-paths@3.15.0:
     dependencies:


### PR DESCRIPTION
- Using `ts-results` didn't make much sense because we weren't doing anything interesting with the results, such as deferring erroring. We wanted to error immediately. It added indirection
- I'm not sure why I was using anonymous functions rather than `function`
- I like putting `export` directly on the function rather than the bottom of the file