### PR TITLE
Handle long entries on Connecticut map

### DIFF
--- a/packages/ct/src/css/overrides.scss
+++ b/packages/ct/src/css/overrides.scss
@@ -1,54 +1,27 @@
-// ---------------------------------------------------------------------
-// Recreate variables from packages/shared
-// ---------------------------------------------------------------------
+// These values come from packages/shared.
+$xs-width: 480px;
+$sm-width: 640px;
 
-$font-size-lg: 18px;
-$min-touch-target: 44px;
-$header-border-width: 4px;
-$element-gap: 10px;
-$border-thickness: 1px;
-$map-controls-margin-top: 6px;
-
-// ---------------------------------------------------------------------
-// Change the header due to long entries
-// ---------------------------------------------------------------------
-
-$dropdown-extra-height: 15px;
-
-$header-height: calc(
-  $min-touch-target + ($element-gap * 2) + $header-border-width +
-    $dropdown-extra-height
-);
-
-$zoom-controls-top-offset: calc(
-  $map-controls-margin-top + $header-height - 92px
-);
-
-.choices[data-type*="select-one"] {
-  .choices__inner {
-    height: calc($min-touch-target + $dropdown-extra-height);
+@mixin gt-xxs() {
+  @media screen and (min-width: $xs-width) {
+    @content();
   }
 }
 
-.leaflet-control-zoom.leaflet-bar {
-  top: $zoom-controls-top-offset;
+@mixin gt-xs() {
+  @media screen and (min-width: $sm-width) {
+    @content();
+  }
 }
 
-#map > div.leaflet-control-container > div.leaflet-top.leaflet-right {
-  $zoom-controls-height: calc(($min-touch-target * 2) + $border-thickness);
-  top: calc($zoom-controls-top-offset + $zoom-controls-height + $element-gap);
+// Make the header wider on large breakpoints.
+.choices[data-type*="select-one"] {
+  .choices__inner {
+    @include gt-xxs() {
+      width: 245px;
+    }
+    @include gt-xs() {
+      width: 270px;
+    }
+  }
 }
-
-.about-popup {
-  top: calc($header-height + 25px);
-}
-
-.scorecard-container {
-  top: calc($header-height + $map-controls-margin-top);
-}
-
-
-.scorecard-title {
-    font-size: $font-size-lg;
-}
-  

--- a/packages/ct/src/css/overrides.scss
+++ b/packages/ct/src/css/overrides.scss
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------
+// Recreate variables from packages/shared
+// ---------------------------------------------------------------------
+
+$font-size-lg: 18px;
+$min-touch-target: 44px;
+$header-border-width: 4px;
+$element-gap: 10px;
+$border-thickness: 1px;
+$map-controls-margin-top: 6px;
+
+// ---------------------------------------------------------------------
+// Change the header due to long entries
+// ---------------------------------------------------------------------
+
+$dropdown-extra-height: 15px;
+
+$header-height: calc(
+  $min-touch-target + ($element-gap * 2) + $header-border-width +
+    $dropdown-extra-height
+);
+
+$zoom-controls-top-offset: calc(
+  $map-controls-margin-top + $header-height - 92px
+);
+
+.choices[data-type*="select-one"] {
+  .choices__inner {
+    height: calc($min-touch-target + $dropdown-extra-height);
+  }
+}
+
+.leaflet-control-zoom.leaflet-bar {
+  top: $zoom-controls-top-offset;
+}
+
+#map > div.leaflet-control-container > div.leaflet-top.leaflet-right {
+  $zoom-controls-height: calc(($min-touch-target * 2) + $border-thickness);
+  top: calc($zoom-controls-top-offset + $zoom-controls-height + $element-gap);
+}
+
+.about-popup {
+  top: calc($header-height + 25px);
+}
+
+.scorecard-container {
+  top: calc($header-height + $map-controls-margin-top);
+}
+
+
+.scorecard-title {
+    font-size: $font-size-lg;
+}
+  

--- a/packages/ct/src/index.html
+++ b/packages/ct/src/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="../../shared/src/css/style.scss" />
+    <link rel="stylesheet" href="./css/overrides.scss" />
   </head>
 
   <body>

--- a/packages/shared/src/css/_controls.scss
+++ b/packages/shared/src/css/_controls.scss
@@ -7,7 +7,7 @@
 
 $label-font-size: typography.$font-size-md;
 $zoom-controls-top-offset: calc(
-  58px + spacing.$map-controls-margin-top - header.$header-height
+  spacing.$map-controls-margin-top - header.$header-height - 80px
 );
 
 .leaflet-left .leaflet-control {

--- a/packages/shared/src/css/_controls.scss
+++ b/packages/shared/src/css/_controls.scss
@@ -7,7 +7,7 @@
 
 $label-font-size: typography.$font-size-md;
 $zoom-controls-top-offset: calc(
-  spacing.$map-controls-margin-top - header.$header-height - 80px
+  58px + spacing.$map-controls-margin-top - header.$header-height
 );
 
 .leaflet-left .leaflet-control {

--- a/packages/shared/src/css/_dropdown.scss
+++ b/packages/shared/src/css/_dropdown.scss
@@ -21,6 +21,15 @@
     border-top-right-radius: borders.$border-radius;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+
+    // Ensure the dropdown does not ever make the header too tall if we have long
+    // entries. Note that the scorecard will already show the full title of the
+    // selected city.
+    .choices__list--single .choices__item--selectable {
+      white-space: nowrap;
+      overflow: hidden;
+      width: 95%;
+    }
   }
 
   &:not(.is-open) {

--- a/packages/shared/src/css/_scorecard.scss
+++ b/packages/shared/src/css/_scorecard.scss
@@ -46,7 +46,11 @@
 
   color: colors.$teal;
   font-weight: bold;
-  font-size: typography.$font-size-xl;
+  font-size: typography.$font-size-lg;
+
+  @include breakpoints.gt-xs {
+    font-size: typography.$font-size-xl;
+  }
 }
 
 .scorecard-accordion-toggle {


### PR DESCRIPTION
Changes:

* Make scorecard title smaller on mobile on both maps so it doesn't cover as much of the map
* Truncate overly wrong dropdown entries when currently chosen
* Make the dropdown wider in CT map
    * But we also don't make it the full width necessary of 300px because it makes the dropdown look way too wide for most entries.