### PR TITLE
Adding Open Graph/Twitter metadata for prettier preview cards

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -13,6 +13,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Use Latest Corepack
+        run: |
+          echo "Before: corepack version => $(corepack --version || echo 'not installed')"
+          npm install -g corepack@latest
+          echo "After : corepack version => $(corepack --version)"
+          corepack enable
       - name: Install dependencies
         run: |
           corepack enable pnpm

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Use Latest Corepack
+        run: |
+          echo "Before: corepack version => $(corepack --version || echo 'not installed')"
+          npm install -g corepack@latest
+          echo "After : corepack version => $(corepack --version)"
+          corepack enable
       - name: Install dependencies
         run: |
           corepack enable pnpm

--- a/packages/ct/src/index.html
+++ b/packages/ct/src/index.html
@@ -4,6 +4,25 @@
     <title>Connecticut Parking Lot Map - Parking Reform Network</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Explore how much land cities in Connecticut dedicate to parking on the map below. Click the drop-down icon in the upper right corner to select a&#8230;"
+    />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:title"
+      content="Connecticut Parking Lot Map &#x2d; Parking Reform Network"
+    />
+    <meta
+      property="og:description"
+      content="Explore how much land cities in Connecticut dedicate to parking on the map below. Click the drop-down icon in the upper right corner to select a city and use the popup info card on the&#8230;"
+    />
+    <meta
+      property="og:url"
+      content="https://parkingreform.org/ct-parking-lots/"
+    />
+    <meta property="og:site_name" content="Parking Reform Network" />
     <link rel="stylesheet" href="../../shared/src/css/style.scss" />
     <link rel="stylesheet" href="./css/overrides.scss" />
   </head>

--- a/packages/ct/src/index.html
+++ b/packages/ct/src/index.html
@@ -28,10 +28,7 @@
       property="og:description"
       content="Explore how much land cities in Connecticut dedicate to parking on the map below. Click the drop-down icon in the upper left corner to select a city and use the popup info card on the&#8230;"
     />
-    <meta
-      property="og:url"
-      content="https://ctparkingreform.org/"
-    />
+    <meta property="og:url" content="https://ctparkingreform.org/" />
     <meta property="og:site_name" content="Parking Reform Network" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta

--- a/packages/ct/src/index.html
+++ b/packages/ct/src/index.html
@@ -22,7 +22,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:title"
-      content="Connecticut Parking Lot Map &#x2d; Parking Reform Network"
+      content="CT Parking Lot Map &#x2d; Parking Reform Network"
     />
     <meta
       property="og:description"
@@ -30,13 +30,13 @@
     />
     <meta
       property="og:url"
-      content="https://parkingreform.org/ct-parking-lots/"
+      content="https://ctparkingreform.org/"
     />
     <meta property="og:site_name" content="Parking Reform Network" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="Connecticut Parking Lot Map &#x2d; Parking Reform Network"
+      content="CT Parking Lot Map &#x2d; Parking Reform Network"
     />
     <meta
       name="twitter:description"

--- a/packages/ct/src/index.html
+++ b/packages/ct/src/index.html
@@ -8,6 +8,16 @@
       name="description"
       content="Explore how much land cities in Connecticut dedicate to parking on the map below. Click the drop-down icon in the upper right corner to select a&#8230;"
     />
+    <meta
+      property="og:image"
+      content="https://parkingreform.org/wp-content/uploads/2025/02/StratfordCT.png"
+    />
+    <meta property="og:image:width" content="1600" />
+    <meta property="og:image:height" content="900" />
+    <meta
+      property="og:image:alt"
+      content='Background image is a map showing where the parking lots are in Stratford, CT.'
+    />
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="website" />
     <meta
@@ -23,6 +33,23 @@
       content="https://parkingreform.org/ct-parking-lots/"
     />
     <meta property="og:site_name" content="Parking Reform Network" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Connecticut Parking Lot Map &#x2d; Parking Reform Network"
+    />
+    <meta
+      name="twitter:description"
+      content="Explore how much land cities in Connecticut dedicate to parking on the map below. Click the drop-down icon in the upper right corner to select a city and use the popup info card on the&#8230;"
+    />
+    <meta
+      name="twitter:image"
+      content="https://parkingreform.org/wp-content/uploads/2025/02/StratfordCT.png"
+    />
+    <meta
+      name="twitter:image:alt"
+      content='Background image is a map showing where the parking lots are in Stratford, CT.'
+    />
     <link rel="stylesheet" href="../../shared/src/css/style.scss" />
     <link rel="stylesheet" href="./css/overrides.scss" />
   </head>

--- a/packages/ct/src/index.html
+++ b/packages/ct/src/index.html
@@ -16,7 +16,7 @@
     <meta property="og:image:height" content="900" />
     <meta
       property="og:image:alt"
-      content='Background image is a map showing where the parking lots are in Stratford, CT.'
+      content="Background image is a map showing where the parking lots are in Stratford, CT."
     />
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="website" />
@@ -48,7 +48,7 @@
     />
     <meta
       name="twitter:image:alt"
-      content='Background image is a map showing where the parking lots are in Stratford, CT.'
+      content="Background image is a map showing where the parking lots are in Stratford, CT."
     />
     <link rel="stylesheet" href="../../shared/src/css/style.scss" />
     <link rel="stylesheet" href="./css/overrides.scss" />


### PR DESCRIPTION
- The image added for previews is the Stratford, CT map. [https://parkingreform.org/wp-content/uploads/2025/02/StratfordCT.png](https://parkingreform.org/wp-content/uploads/2025/02/StratfordCT.png)
- Updated/added the text descriptions.
- The original PRN map has `og:url` going to the [general Parking Lot Map resource page](https://parkingreform.org/resources/parking-lot-map/). Since there isn't an equivalent for the CT parking lot map I'm linking to [https://parkingreform.org/ct-parking-lots](https://parkingreform.org/ct-parking-lots) but could see an argument for [https://ctparkingreform.org](https://ctparkingreform.org). Happy to update either way.
- "Connecticut Parking Lot Map" is quite long, let me know if you think we should update it to "CT Parking Lot Map"

Preview of current FB card rendering:
<img width="362" alt="image" src="https://github.com/user-attachments/assets/568ac4c3-c20a-4d5e-a4e3-575bafc64bc9" />