### PR TITLE
DRY Sass with shared mixins and tokens

### DIFF
--- a/packages/shared/src/css/_about.scss
+++ b/packages/shared/src/css/_about.scss
@@ -1,7 +1,7 @@
-@use "theme/borders";
 @use "theme/breakpoints";
 @use "theme/colors";
 @use "theme/icons";
+@use "theme/mixins";
 @use "theme/spacing";
 @use "theme/typography";
 
@@ -16,8 +16,7 @@
   font-size: typography.$font-size-base;
   padding: spacing.$container-edge-spacing;
 
-  border: borders.$component-border;
-  border-radius: borders.$border-radius;
+  @include mixins.panel-border;
 
   overflow-y: auto;
   overflow-wrap: break-word;
@@ -38,34 +37,25 @@
 }
 
 .about-popup-header {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
   width: 100%;
+
+  @include mixins.flex-center($display: inline-flex);
 
   h2 {
     flex: 1;
     margin: 0;
     margin-right: spacing.$element-gap;
-    line-height: 1.3;
+    line-height: typography.$line-height-base;
     font-size: typography.$font-size-xl;
-    font-weight: 500;
+    font-weight: typography.$font-weight-medium;
   }
 }
 
 .about-popup-close-icon-container {
-  cursor: pointer;
-  height: spacing.$min-touch-target;
-  width: spacing.$min-touch-target;
   margin-left: auto;
 
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  &:hover {
-    background-color: colors.$hover-white;
-  }
+  @include mixins.icon-button-container;
+  @include mixins.hover-highlight;
 
   svg {
     height: icons.$icon-size-md;

--- a/packages/shared/src/css/_controls.scss
+++ b/packages/shared/src/css/_controls.scss
@@ -1,5 +1,6 @@
 @use "theme/borders";
 @use "theme/colors";
+@use "theme/mixins";
 @use "theme/spacing";
 @use "theme/typography";
 @use "theme/zindex";
@@ -16,8 +17,7 @@ $zoom-controls-top-offset: calc(
 
 .leaflet-control-zoom.leaflet-bar.leaflet-control,
 .leaflet-control-layers.leaflet-control {
-  border: borders.$component-border;
-  border-radius: borders.$border-radius;
+  @include mixins.panel-border;
 }
 
 .leaflet-control-zoom.leaflet-bar {
@@ -27,11 +27,9 @@ $zoom-controls-top-offset: calc(
     width: spacing.$min-touch-target;
     height: spacing.$min-touch-target;
     font-size: $label-font-size;
-    font-weight: normal;
+    font-weight: typography.$font-weight-regular;
 
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    @include mixins.flex-center;
 
     &:hover,
     &:focus {
@@ -89,8 +87,7 @@ $zoom-controls-top-offset: calc(
     border-bottom: borders.$component-inner-divider;
   }
 
-  display: flex;
-  align-items: center;
+  @include mixins.flex-center($justify: flex-start);
 
   $padding-y: calc((spacing.$min-touch-target - $label-font-size) / 2);
   padding: $padding-y spacing.$element-gap;
@@ -100,7 +97,5 @@ $zoom-controls-top-offset: calc(
     vertical-align: middle;
   }
 
-  &:hover {
-    background-color: colors.$hover-white;
-  }
+  @include mixins.hover-highlight;
 }

--- a/packages/shared/src/css/_dropdown.scss
+++ b/packages/shared/src/css/_dropdown.scss
@@ -12,7 +12,7 @@
   .choices__inner {
     color: colors.$black;
     font-size: typography.$font-size-base;
-    line-height: 1.2; // To vertically center the text.
+    line-height: typography.$line-height-snug; // To vertically center the text.
 
     height: spacing.$min-touch-target;
     width: 220px;
@@ -66,6 +66,6 @@ div.choices__item.choices__item--choice.choices__item--selectable {
 .choices__list--dropdown .choices__item--selectable,
 .choices__list[aria-expanded] .choices__item--selectable {
   // Choices.js sets this to 100px to account for itemSelectText. But we disable that,
-  // so we want to use the normal padding it would otherwise use of 10px.
-  padding-right: 10px;
+  // so we want to use the normal padding it would otherwise use.
+  padding-right: spacing.$element-gap;
 }

--- a/packages/shared/src/css/_header.scss
+++ b/packages/shared/src/css/_header.scss
@@ -1,8 +1,8 @@
-@use "theme/borders";
 @use "theme/breakpoints";
 @use "theme/colors";
 @use "theme/spacing";
 @use "theme/icons";
+@use "theme/mixins";
 
 // We don't use $container-edge-spacing to save vertical space.
 $header-y-padding: spacing.$element-gap;
@@ -29,17 +29,8 @@ $header-height: calc(
 }
 
 .header-icon-container {
-  height: spacing.$min-touch-target;
-  width: spacing.$min-touch-target;
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-
-  &:hover {
-    background-color: colors.$hover-gray;
-  }
+  @include mixins.icon-button-container;
+  @include mixins.hover-highlight(colors.$hover-gray);
 
   svg {
     color: colors.$white;

--- a/packages/shared/src/css/_scorecard.scss
+++ b/packages/shared/src/css/_scorecard.scss
@@ -3,6 +3,7 @@
 @use "theme/colors";
 @use "theme/spacing";
 @use "theme/icons";
+@use "theme/mixins";
 @use "theme/typography";
 @use "theme/zindex";
 @use "header";
@@ -17,9 +18,9 @@
   width: 260px;
 
   background-color: colors.$white;
-  border: borders.$component-border;
-  border-radius: borders.$border-radius;
   color: colors.$black;
+
+  @include mixins.panel-border;
 
   @include breakpoints.gte-xs {
     width: 280px;
@@ -42,10 +43,10 @@
   margin-bottom: spacing.$element-gap;
   margin-left: spacing.$container-edge-spacing;
   margin-right: spacing.$container-edge-spacing;
-  line-height: 1.1;
+  line-height: typography.$line-height-tight;
 
   color: colors.$teal;
-  font-weight: bold;
+  font-weight: typography.$font-weight-bold;
   font-size: typography.$font-size-lg;
 
   @include breakpoints.gte-sm {
@@ -70,9 +71,7 @@ summary.scorecard-accordion-toggle {
     display: none;
   }
 
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  @include mixins.flex-center($justify: space-between);
 
   border-left: 0;
   border-right: 0;
@@ -81,20 +80,16 @@ summary.scorecard-accordion-toggle {
   border-bottom-left-radius: borders.$border-radius;
   border-bottom-right-radius: borders.$border-radius;
 
-  &:hover {
-    background-color: colors.$hover-white;
-  }
+  @include mixins.hover-highlight;
 
   .scorecard-accordion-title {
     flex: 1;
   }
 
   .scorecard-accordion-icon-container {
+    @include mixins.flex-center($display: inline-flex);
     height: spacing.$min-touch-target;
     width: spacing.$min-touch-target;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
 
     svg {
       height: icons.$icon-size-sm;

--- a/packages/shared/src/css/theme/_colors.scss
+++ b/packages/shared/src/css/theme/_colors.scss
@@ -1,6 +1,5 @@
 $teal: hsl(173, 72%, 46%);
 $white: hsl(0, 0%, 100%);
-$hover: hsl(0, 0%, 96%);
 $black: hsl(0, 0%, 0%);
 $gray: hsl(0, 0%, 25.88%); // Color comes from the logo
 $gray-light: hsl(0, 0%, 80%);
@@ -9,3 +8,6 @@ $black-translucent: hsla(0, 0%, 0%, 0.4);
 
 $hover-white: hsl(0, 0%, 96%);
 $hover-gray: hsl(0, 0%, 32%);
+
+$link: hsl(208, 56%, 46%);
+$link-hover: hsl(208, 56%, 31%);

--- a/packages/shared/src/css/theme/_links.scss
+++ b/packages/shared/src/css/theme/_links.scss
@@ -1,10 +1,12 @@
+@use "colors";
+
 a {
-  color: #337ab7;
+  color: colors.$link;
   text-decoration: none;
 
   &:hover,
   &:focus {
-    color: #23527c;
+    color: colors.$link-hover;
     text-decoration: underline;
   }
 }

--- a/packages/shared/src/css/theme/_mixins.scss
+++ b/packages/shared/src/css/theme/_mixins.scss
@@ -1,0 +1,28 @@
+@use "borders";
+@use "colors";
+@use "spacing";
+
+@mixin flex-center($display: flex, $justify: center) {
+  display: $display;
+  align-items: center;
+  justify-content: $justify;
+}
+
+@mixin panel-border {
+  border: borders.$component-border;
+  border-radius: borders.$border-radius;
+}
+
+@mixin icon-button-container($display: inline-flex) {
+  cursor: pointer;
+  height: spacing.$min-touch-target;
+  width: spacing.$min-touch-target;
+
+  @include flex-center($display);
+}
+
+@mixin hover-highlight($color: colors.$hover-white) {
+  &:hover {
+    background-color: $color;
+  }
+}

--- a/packages/shared/src/css/theme/_resets.scss
+++ b/packages/shared/src/css/theme/_resets.scss
@@ -1,3 +1,6 @@
+@use "spacing";
+@use "typography";
+
 * {
   box-sizing: border-box;
 }
@@ -35,14 +38,14 @@ ol {
   margin-top: 0;
   margin-bottom: 10px;
   padding: 0;
-  padding-inline-start: 20px; // Default is 40px
+  padding-inline-start: spacing.$list-indent;
 }
 
 p,
 li,
 dd,
 a {
-  line-height: 1.3;
+  line-height: typography.$line-height-base;
 }
 
 // Visually hide an element while keeping it available to screen readers.

--- a/packages/shared/src/css/theme/_spacing.scss
+++ b/packages/shared/src/css/theme/_spacing.scss
@@ -6,3 +6,6 @@ $map-controls-margin-top: 6px;
 
 $container-edge-spacing: 15px;
 $element-gap: 10px;
+
+// Default `padding-inline-start` for lists is 40px; use this for a tighter list.
+$list-indent: 20px;

--- a/packages/shared/src/css/theme/_typography.scss
+++ b/packages/shared/src/css/theme/_typography.scss
@@ -6,6 +6,14 @@ $font-size-lg: 20px;
 $font-size-xl: 24px;
 $font-size-2xl: 30px;
 
+$line-height-tight: 1.1;
+$line-height-snug: 1.2;
+$line-height-base: 1.3;
+
+$font-weight-regular: normal;
+$font-weight-medium: 500;
+$font-weight-bold: bold;
+
 body,
 .leaflet-container {
   font-family: Poppins, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Adds theme/_mixins.scss (flex-center, panel-border, icon-button-container, hover-highlight) to replace repeated flex/border/hover declarations across components, and tokenizes line-heights, font-weights, list indent, and link colors that were previously magic numbers/hardcoded hex. Verified the compiled CSS output is unchanged (mixins.scss inspired by the same DRY pass on mandates-map).