### PR TITLE
Test that city IDs agree across stats, boundaries, and parking-lots

### DIFF
--- a/packages/ct/data/city-stats.json
+++ b/packages/ct/data/city-stats.json
@@ -1238,13 +1238,6 @@
     "transitStation": null,
     "county": "Fairfield County"
   },
-  "westport-green's-farms": {
-    "name": "Westport - Green's Farms",
-    "percentage": "58%",
-    "population": "27,141",
-    "transitStation": "Green's Farms",
-    "county": "Fairfield County"
-  },
   "westport-saugatuck": {
     "name": "Westport - Saugatuck",
     "percentage": "47%",

--- a/packages/scripts/tests/dataFolder.test.ts
+++ b/packages/scripts/tests/dataFolder.test.ts
@@ -26,3 +26,29 @@ test("city-stats.json is sorted alphabetically", async () => {
   await assertSortedStats("../ct/data/city-stats.json");
   await assertSortedStats("../primary/data/city-stats.json");
 });
+
+async function assertKeysAgree(dataDir: string): Promise<void> {
+  const stats = JSON.parse(
+    await fs.readFile(`${dataDir}/city-stats.json`, "utf8"),
+  );
+  const statsKeys = Object.keys(stats).sort();
+
+  const boundaries = JSON.parse(
+    await fs.readFile(`${dataDir}/city-boundaries.geojson`, "utf8"),
+  );
+  const boundaryIds = boundaries.features
+    .map((feature: { properties: { id: string } }) => feature.properties.id)
+    .sort();
+
+  const parkingLotFiles = (await fs.readdir(`${dataDir}/parking-lots`))
+    .map((fileName) => fileName.replace(/\.geojson$/, ""))
+    .sort();
+
+  expect(boundaryIds).toEqual(statsKeys);
+  expect(parkingLotFiles).toEqual(statsKeys);
+}
+
+test("city-stats.json, city-boundaries.geojson, and parking-lots/ agree on city IDs", async () => {
+  await assertKeysAgree("../ct/data");
+  await assertKeysAgree("../primary/data");
+});


### PR DESCRIPTION
Previously dataFolder.test.ts only checked alphabetical ordering, so a boundary id missing from city-stats.json (or vice versa) would silently yield undefined stats, later dereferenced in scorecard.ts. Add a check that the three data sources' key sets match exactly.

This caught a real orphan entry: ct's "westport-green's-farms" had a stats entry but no matching boundary feature or parking-lots file, so it was removed.