### PR TITLE
Fix CT score card schema drift and DRY up scripts/base.ts

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -14,6 +14,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "@prn-parking-lots/ct": "workspace:*",
+    "@prn-parking-lots/primary": "workspace:*",
     "tsx": "^4.19.2"
   }
 }

--- a/packages/scripts/src/add-city.ts
+++ b/packages/scripts/src/add-city.ts
@@ -1,63 +1,65 @@
 import fs from "node:fs/promises";
-import type { CityId } from "@prn-parking-lots/shared/src/js/model/types.ts";
+import type { CityStats as CtCityStats } from "@prn-parking-lots/ct/src/js/types.ts";
+import type { CityStats as PrimaryCityStats } from "@prn-parking-lots/primary/src/js/types.ts";
+import type {
+  BaseCityStats,
+  CityId,
+} from "@prn-parking-lots/shared/src/js/model/types.ts";
 import {
+  compareIds,
   determineArgs,
   type Pkg,
+  readJson,
   updateCoordinates,
   updateParkingLots,
 } from "./base.ts";
 import { runScript } from "./runScript.ts";
 
-async function addScoreCard(
-  pkg: Pkg,
-  cityId: CityId,
-  cityName: string,
-): Promise<void> {
-  const common = {
+function buildPrimaryEntry(cityName: string): PrimaryCityStats {
+  return {
     name: cityName,
     percentage: "FILL ME IN, e.g. 23%",
     population: "FILL ME IN, e.g. 346,824",
     reforms:
       'FILL ME IN, with "repealed", "adopted", or "proposed". If none apply, remove the quotes and set to null',
     url: "FILL ME IN. If not relevant, remove the quotes and set to null",
+    cityType: "FILL ME IN, e.g. Core City",
+    urbanizedAreaPopulation: "FILL ME IN, e.g. 13,200,998",
+    parkingScore:
+      "FILL ME IN, e.g. 53. If not relevant, remove the quotes and set to null",
+    contribution:
+      "FILL ME IN with the email of the contributor. If it's an official map, remove the quotes and set to null",
   };
-  let newEntry: Record<string, string>;
-  if (pkg === "ct") {
-    newEntry = {
-      ...common,
-      group: "FILL ME IN, either 'Group 1', 'Group 2', or 'Group 3'",
-    };
-  } else {
-    newEntry = {
-      ...common,
-      cityType: "FILL ME IN, e.g. Core City",
-      urbanizedAreaPopulation: "FILL ME IN, e.g. 13,200,998",
-      parkingScore:
-        "FILL ME IN, e.g. 53. If not relevant, remove the quotes and set to null",
-      contribution:
-        "FILL ME IN with the email of the contributor. If it's an official map, remove the quotes and set to null",
-    };
-  }
+}
 
+function buildCtEntry(cityName: string): CtCityStats {
+  return {
+    name: cityName,
+    percentage: "FILL ME IN, e.g. 23%",
+    population: "FILL ME IN, e.g. 346,824",
+    transitStation:
+      "FILL ME IN with the transit station name. If none, remove the quotes and set to null",
+    county: "FILL ME IN, e.g. Hartford County",
+  };
+}
+
+async function addScoreCard<T extends BaseCityStats>(
+  pkg: Pkg,
+  cityId: CityId,
+  newEntry: T,
+): Promise<void> {
   const filePath = `packages/${pkg}/data/city-stats.json`;
-  let originalData: Record<string, Record<string, string>>;
-  try {
-    const rawOriginalData = await fs.readFile(filePath, "utf8");
-    originalData = JSON.parse(rawOriginalData);
-  } catch (err: unknown) {
-    const { message } = err as Error;
-    throw new Error(
-      `Issue reading the score card file path ${filePath}: ${message}`,
-    );
-  }
+  const originalData = await readJson<Record<string, T>>(
+    filePath,
+    "score card",
+  );
 
   originalData[cityId] = newEntry;
 
-  const sortedKeys = Object.keys(originalData).sort();
-  const sortedData: Record<string, Record<string, string>> = {};
-  sortedKeys.forEach((key) => {
+  const sortedData: Record<string, T> = {};
+  for (const key of Object.keys(originalData).sort(compareIds)) {
     sortedData[key] = originalData[key];
-  });
+  }
 
   await fs.writeFile(filePath, JSON.stringify(sortedData, null, 2));
 }
@@ -83,7 +85,11 @@ async function main(): Promise<void> {
     `packages/${pkg}/data/parking-lots/${cityId}.geojson`,
   );
 
-  await addScoreCard(pkg, cityId, cityName);
+  if (pkg === "ct") {
+    await addScoreCard(pkg, cityId, buildCtEntry(cityName));
+  } else {
+    await addScoreCard(pkg, cityId, buildPrimaryEntry(cityName));
+  }
 
   console.log(
     `Almost done! Now, fill in the score card values in packages/${pkg}/data/city-stats.json. ` +

--- a/packages/scripts/src/base.ts
+++ b/packages/scripts/src/base.ts
@@ -35,6 +35,31 @@ export function determineArgs(
   return { pkg, cityName, cityId };
 }
 
+export async function readJson<T>(
+  filePath: string,
+  description: string,
+): Promise<T> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch (err: unknown) {
+    const { message } = err as Error;
+    throw new Error(
+      `Issue reading the ${description} file path ${filePath}: ${message}`,
+    );
+  }
+}
+
+export function compareIds(a: string, b: string): number {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}
+
 export async function updateCoordinates(
   scriptCommand: string,
   cityId: CityId,
@@ -42,16 +67,10 @@ export async function updateCoordinates(
   originalFilePath: string,
   updateFilePath: string,
 ): Promise<void> {
-  let newData: FeatureCollection<Polygon, GeoJsonProperties>;
-  try {
-    const rawNewData = await fs.readFile(updateFilePath, "utf8");
-    newData = JSON.parse(rawNewData);
-  } catch (err: unknown) {
-    const { message } = err as Error;
-    throw new Error(
-      `Issue reading the update file path ${updateFilePath}: ${message}`,
-    );
-  }
+  const newData = await readJson<FeatureCollection<Polygon, GeoJsonProperties>>(
+    updateFilePath,
+    "update",
+  );
 
   if (!Array.isArray(newData.features) || newData.features.length !== 1) {
     throw new Error(
@@ -63,16 +82,9 @@ export async function updateCoordinates(
   const newCoordinates = polygon.coordinates;
   const newGeometryType = polygon.type;
 
-  let originalData: FeatureCollection<Polygon, GeoJsonProperties>;
-  try {
-    const rawOriginalData = await fs.readFile(originalFilePath, "utf8");
-    originalData = JSON.parse(rawOriginalData);
-  } catch (err: unknown) {
-    const { message } = err as Error;
-    throw new Error(
-      `Issue reading the original data file path ${originalFilePath}: ${message}`,
-    );
-  }
+  const originalData = await readJson<
+    FeatureCollection<Polygon, GeoJsonProperties>
+  >(originalFilePath, "original data");
 
   if (addCity) {
     const newEntry = {
@@ -94,15 +106,9 @@ export async function updateCoordinates(
   }
 
   // Make sure the data is still sorted.
-  originalData.features.sort((a, b) => {
-    if (a.properties?.id < b.properties?.id) {
-      return -1;
-    }
-    if (a.properties?.id > b.properties?.id) {
-      return 1;
-    }
-    return 0;
-  });
+  originalData.features.sort((a, b) =>
+    compareIds(a.properties?.id, b.properties?.id),
+  );
 
   await fs.writeFile(originalFilePath, JSON.stringify(originalData, null, 2));
 }
@@ -110,19 +116,13 @@ export async function updateCoordinates(
 export async function updateParkingLots(
   cityId: CityId,
   addCity: boolean,
-  originalFilePath: string,
   updateFilePath: string,
+  originalFilePath: string,
 ): Promise<void> {
-  let newData: FeatureCollection<Polygon, GeoJsonProperties>;
-  try {
-    const rawNewData = await fs.readFile(originalFilePath, "utf8");
-    newData = JSON.parse(rawNewData);
-  } catch (err: unknown) {
-    const { message } = err as Error;
-    throw new Error(
-      `Issue reading the update file path parking-lots-update.geojson: ${message}`,
-    );
-  }
+  const newData = await readJson<FeatureCollection<Polygon, GeoJsonProperties>>(
+    updateFilePath,
+    "update",
+  );
 
   if (!Array.isArray(newData.features) || newData.features.length !== 1) {
     throw new Error(
@@ -134,19 +134,13 @@ export async function updateParkingLots(
   const newGeometryType = newData.features[0].geometry.type;
 
   if (!addCity) {
-    let originalData: Feature<Polygon, GeoJsonProperties>;
-    try {
-      const rawOriginalData = await fs.readFile(updateFilePath, "utf8");
-      originalData = JSON.parse(rawOriginalData);
-    } catch (err: unknown) {
-      const { message } = err as Error;
-      throw new Error(
-        `Issue reading the original data file path ${updateFilePath}: ${message}`,
-      );
-    }
+    const originalData = await readJson<Feature<Polygon, GeoJsonProperties>>(
+      originalFilePath,
+      "original data",
+    );
     originalData.geometry.coordinates = newCoordinates;
 
-    await fs.writeFile(updateFilePath, JSON.stringify(originalData, null, 2));
+    await fs.writeFile(originalFilePath, JSON.stringify(originalData, null, 2));
     return;
   }
 
@@ -155,5 +149,5 @@ export async function updateParkingLots(
     properties: { id: cityId },
     geometry: { type: newGeometryType, coordinates: newCoordinates },
   };
-  await fs.writeFile(updateFilePath, JSON.stringify(newFile, null, 2));
+  await fs.writeFile(originalFilePath, JSON.stringify(newFile, null, 2));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,12 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      '@prn-parking-lots/ct':
+        specifier: workspace:*
+        version: link:../ct
+      '@prn-parking-lots/primary':
+        specifier: workspace:*
+        version: link:../primary
       tsx:
         specifier: ^4.19.2
         version: 4.23.0


### PR DESCRIPTION
addScoreCard was writing primary's fields (reforms/url/group) into CT entries instead of CT's actual schema (transitStation/county). Entries are now built from the real CityStats types per package so this can't drift silently again. 

Also extracts a shared readJson helper to remove 4x-duplicated read/parse/error-wrap blocks, fixes a hardcoded wrong filename in an error message, unifies two divergent sort implementations, and renames updateParkingLots's inverted originalFilePath/updateFilePath params for clarity.